### PR TITLE
Add method to get names for an edge.

### DIFF
--- a/src/baldr/graphtile.cc
+++ b/src/baldr/graphtile.cc
@@ -1,6 +1,7 @@
 #include "baldr/graphtile.h"
 
 #include <string>
+#include <vector>
 #include <iostream>
 #include <fstream>
 
@@ -54,6 +55,8 @@ GraphTile::GraphTile(const std::string& basedirectory, const GraphId& graphid)
     // Start of edge information and name list
     edgeinfo_ = graphtile_.get() + header_->edgeinfo_offset();
     textlist_ = graphtile_.get() + header_->textlist_offset();
+
+    textsize_ = filesize - header_->textlist_offset();
 
     // Set the size to indicate success
     size_ = filesize;
@@ -128,6 +131,26 @@ const DirectedEdge* GraphTile::GetDirectedEdges(const uint32_t node_index,
   count = nodeinfo->edge_count();
   edge_index = nodeinfo->edge_index();
   return directededge(nodeinfo->edge_index());
+}
+
+// Convenience method to get the names for an edge.
+std::vector<std::string>& GraphTile::GetNames(const uint32_t edgeinfo_offset,
+                  std::vector<std::string>& names) {
+  // Get each name
+  names.clear();
+  uint32_t offset;
+  const EdgeInfo* edge = edgeinfo(edgeinfo_offset);
+  uint32_t namecount = edge->name_count();
+  for (uint32_t i = 0; i < namecount; i++) {
+    offset = edge->GetStreetNameOffset(i);
+std::cout << i << ":Name Offset = " << offset << " textlist size = " << textsize_ << std::endl;
+    if (offset < textsize_) {
+      names.push_back(textlist_ + offset);
+    } else {
+      std::cout << "ERROR - offset exceeds size of text list" << std::endl;
+    }
+  }
+  return names;
 }
 
 }

--- a/valhalla/baldr/graphtile.h
+++ b/valhalla/baldr/graphtile.h
@@ -116,6 +116,12 @@ class GraphTile {
   const DirectedEdge* GetDirectedEdges(const uint32_t node_index,
                                        uint32_t& count, uint32_t& edge_index);
 
+  /**
+   * Convenience method to get the names for an edge.
+   */
+  std::vector<std::string>& GetNames(const uint32_t edgeinfo_offset,
+                 std::vector<std::string>& names);
+
  protected:
   // Size of the tile in bytes
   size_t size_;
@@ -141,6 +147,9 @@ class GraphTile {
   // Street names and exit names/numbers as sets of null-terminated char arrays.
   // Edge info has offsets into this array.
   char* textlist_;
+
+  // Number of bytes in the text/name list
+  uint32_t textsize_;
 
   // The id of the tile for convenience
   const GraphId id_;


### PR DESCRIPTION
 Protect against offsets exceeding the size of the names list.

@dgearhart @gknisely @kevinkreiser 