### PR TITLE
Return speed as int

### DIFF
--- a/src/baldr/directededge.cc
+++ b/src/baldr/directededge.cc
@@ -35,6 +35,11 @@ uint8_t DirectedEdge::reverseaccess() const {
   return reverseaccess_.v;
 }
 
+// Gets the speed in KPH.
+uint8_t DirectedEdge::speed() const {
+  return speed_;
+}
+
 // TODO - methods for individual access
 
 bool DirectedEdge::ferry() const {
@@ -104,11 +109,6 @@ RoadClass DirectedEdge::importance() const {
 // Get the use of this edge.
 Use DirectedEdge::use() const {
   return static_cast<Use>(classification_.use);
-}
-
-// Gets the speed in KPH.
-float DirectedEdge::speed() const {
-  return static_cast<float>(speed_);
 }
 
 }

--- a/valhalla/baldr/directededge.h
+++ b/valhalla/baldr/directededge.h
@@ -58,7 +58,7 @@ class DirectedEdge {
    * Gets the speed in KPH. TODO - cast to float instead?
    * @return  Returns the speed in KPH.
    */
-  float speed() const;
+  uint8_t speed() const;
 
   /**
    * Offset to the common edge data. The offset is from the start


### PR DESCRIPTION
Will use "speed  cost factors" rather than dividing through by speed.  So don't want to return float

@dgearhart @gknisely @kevinkreiser 