### PR TITLE
lat, lon parse order

### DIFF
--- a/src/baldr/location.cc
+++ b/src/baldr/location.cc
@@ -29,7 +29,7 @@ namespace baldr{
       throw std::runtime_error("Bad format for csv formated location");
 
     //make the lng, lat
-    midgard::PointLL ll(std::stof(parts[0]), std::stof(parts[1]));
+    midgard::PointLL ll(std::stof(parts[1]), std::stof(parts[0]));
 
     //check for info about the stop type
     if(parts.size() > 2 && parts[2] == "through")

--- a/test/location.cc
+++ b/test/location.cc
@@ -23,11 +23,11 @@ namespace {
     }
 
     Location csv = Location::FromCsv("1.452,3.45");
-    if(csv.latlng_.x() != std::stof("1.452") || csv.latlng_.y() != std::stof("3.45")|| csv.stoptype_ != Location::StopType::BREAK)
+    if(csv.latlng_.y() != std::stof("1.452") || csv.latlng_.x() != std::stof("3.45")|| csv.stoptype_ != Location::StopType::BREAK)
       throw std::runtime_error("Csv location parsing failed");
 
     csv = Location::FromCsv("1.452,-3.45,through");
-        if(csv.latlng_.x() != std::stof("1.452") || csv.latlng_.y() != std::stof("-3.45") || csv.stoptype_ != Location::StopType::THROUGH)
+        if(csv.latlng_.y() != std::stof("1.452") || csv.latlng_.x() != std::stof("-3.45") || csv.stoptype_ != Location::StopType::THROUGH)
           throw std::runtime_error("Csv location parsing failed");
 
     Location b(PointLL{1,2});


### PR DESCRIPTION
so to match the code i changed the parsing of lat lon to be lon lat but that seems to be not a convention humans use to much. so i'm changing it back. this will change anything that parses strings into `PointLL` objects or `Location` objects.