### PR TITLE
Add GetNames method that takes the edgeinfo shared ptr. Add comments.

### DIFF
--- a/src/baldr/graphtile.cc
+++ b/src/baldr/graphtile.cc
@@ -114,12 +114,14 @@ const NodeInfo* GraphTile::node(const size_t idx) const {
   throw std::runtime_error("GraphTile NodeInfo index out of bounds");
 }
 
+// Get the directed edge given a GraphId
 const DirectedEdge* GraphTile::directededge(const GraphId& edge) const {
   if (edge.id() < header_->directededgecount())
     return &directededges_[edge.id()];
   throw std::runtime_error("GraphTile DirectedEdge id out of bounds");
 }
 
+// Get the directed edge at the specified index.
 const DirectedEdge* GraphTile::directededge(const size_t idx) const {
   if (idx < header_->directededgecount())
     return &directededges_[idx];
@@ -130,6 +132,7 @@ const std::shared_ptr<EdgeInfo> GraphTile::edgeinfo(const size_t offset) const {
   return std::make_shared<EdgeInfo>(edgeinfo_ + offset);
 }
 
+// Get the directed edges outbound from the specified node index.
 const DirectedEdge* GraphTile::GetDirectedEdges(const uint32_t node_index,
                                                 uint32_t& count,
                                                 uint32_t& edge_index) {
@@ -139,20 +142,28 @@ const DirectedEdge* GraphTile::GetDirectedEdges(const uint32_t node_index,
   return directededge(nodeinfo->edge_index());
 }
 
-// Convenience method to get the names for an edge.
+// Convenience method to get the names for an edge given the offset to the
+// edge info
 std::vector<std::string>& GraphTile::GetNames(const uint32_t edgeinfo_offset,
                                               std::vector<std::string>& names) {
-  // Get each name
+  const std::shared_ptr<EdgeInfo> edge = edgeinfo(edgeinfo_offset);
+  return GetNames(edgeinfo(edgeinfo_offset), names);
+}
+
+// Convenience method to get the names for an edge given an edgeinfo shared
+// pointer.
+std::vector<std::string>& GraphTile::GetNames(
+            const std::shared_ptr<EdgeInfo>& edge,
+            std::vector<std::string>& names) {
+  // Clear the list of names and get each name
   names.clear();
   uint32_t offset;
-  const std::shared_ptr<EdgeInfo> edge = edgeinfo(edgeinfo_offset);
-  uint32_t namecount = edge->name_count();
-  for (uint32_t i = 0; i < namecount; i++) {
+  for (uint32_t i = 0, n = edge->name_count(); i < n; i++) {
     offset = edge->GetStreetNameOffset(i);
     if (offset < textlist_size_) {
       names.push_back(textlist_ + offset);
     } else {
-      std::cout << "ERROR - offset exceeds size of text list" << std::endl;
+      throw std::runtime_error("GetNames: offset exceeds size of text list");
     }
   }
   return names;

--- a/valhalla/baldr/graphtile.h
+++ b/valhalla/baldr/graphtile.h
@@ -118,9 +118,23 @@ class GraphTile {
                                        uint32_t& count, uint32_t& edge_index);
 
   /**
-   * Convenience method to get the names for an edge.
+   * Convenience method to get the names for an edge given the offset to the
+   * edge information.
+   * @param  edgeinfo_offset  Offset to the edge info.
+   * @param  names            (OUT) Vector to hold list of names
+   * @return  Returns an address to the list of names.
    */
   std::vector<std::string>& GetNames(const uint32_t edgeinfo_offset,
+                 std::vector<std::string>& names);
+
+  /**
+   * Convenience method to get the names for an edge given an edgeinfo
+   * shared pointer.
+   * @param  edge  Shared pointer to the edge information.
+   * @param  names (OUT) Vector to hold list of names
+   * @return  Returns an address to the list of names.
+   */
+  std::vector<std::string>& GetNames(const std::shared_ptr<EdgeInfo>& edge,
                  std::vector<std::string>& names);
 
  protected:


### PR DESCRIPTION
Often we have the shared ptr, so no need to get it again when retrieving names.