### PR TITLE
tile uri generation to make sure not too many files in one dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ test-driver
 test/location
 test/graphid
 test/tilehierarchy
+test/graphtile
 test/*.log
 test/*.trs
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -69,7 +69,8 @@ libvalhalla_baldr_la_LIBADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) @BOOST_LDFLAGS@
 check_PROGRAMS = \
 	test/location \
 	test/graphid \
-	test/tilehierarchy 
+	test/tilehierarchy \
+	test/graphtile
 test_location_SOURCES = test/location.cc test/test.cc
 test_location_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_CPPFLAGS)
 test_location_LDADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) libvalhalla_baldr.la
@@ -79,6 +80,9 @@ test_graphid_LDADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) libvalhalla_baldr.la
 test_tilehierarchy_SOURCES = test/tilehierarchy.cc test/test.cc
 test_tilehierarchy_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_CPPFLAGS)
 test_tilehierarchy_LDADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) libvalhalla_baldr.la
+test_graphtile_SOURCES = test/graphtile.cc test/test.cc
+test_graphtile_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_CPPFLAGS)
+test_graphtile_LDADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) libvalhalla_baldr.la
 
 
 TESTS = $(check_PROGRAMS)

--- a/src/baldr/graphreader.cc
+++ b/src/baldr/graphreader.cc
@@ -30,7 +30,7 @@ GraphTile* GraphReader::GetGraphTile(const GraphId& graphid) {
     return &cached->second;
 
   // It wasn't in cache so create a GraphTile object. This reads the tile from disk
-  GraphTile tile(tile_hierarchy_.tile_dir(), graphid);
+  GraphTile tile(tile_hierarchy_, graphid);
   // Need to check that the tile could be loaded, if it has no size it wasn't loaded
   if(tile.size() == 0)
     return nullptr;

--- a/src/baldr/graphtile.cc
+++ b/src/baldr/graphtile.cc
@@ -102,7 +102,7 @@ GraphTile::GraphTile(const TileHierarchy& hierarchy, const GraphId& graphid)
 GraphTile::~GraphTile() {
 }
 
-std::string GraphTile::FileSuffix(const GraphId& graphid, const TileHierarchy& heirarchy) {
+std::string GraphTile::FileSuffix(const GraphId& graphid, const TileHierarchy& hierarchy) {
   /*
   if you have a graphid where level == 8 and tileid == 24134109851
   you should get: 8/024/134/109/851.gph
@@ -115,8 +115,8 @@ std::string GraphTile::FileSuffix(const GraphId& graphid, const TileHierarchy& h
   */
 
   //figure the largest id for this level
-  auto level = heirarchy.levels().find(graphid.level());
-  if(level == heirarchy.levels().end())
+  auto level = hierarchy.levels().find(graphid.level());
+  if(level == hierarchy.levels().end())
     throw std::runtime_error("Could not compute FileSuffix for non-existent level");
   uint32_t max_id = Tiles::MaxTileId(AABB2(PointLL(-180, -90), PointLL(180, 90)), level->second.tiles.TileSize());
 
@@ -194,15 +194,12 @@ const DirectedEdge* GraphTile::GetDirectedEdges(const uint32_t node_index,
 }
 
 // Convenience method to get the names for an edge.
-std::vector<std::string>& GraphTile::GetNames(const uint32_t edgeinfo_offset,
-                                              std::vector<std::string>& names) {
+std::vector<std::string> GraphTile::GetNames(const uint32_t edgeinfo_offset) {
   // Get each name
-  names.clear();
-  uint32_t offset;
+  std::vector<std::string> names;
   const std::shared_ptr<EdgeInfo> edge = edgeinfo(edgeinfo_offset);
-  uint32_t namecount = edge->name_count();
-  for (uint32_t i = 0; i < namecount; i++) {
-    offset = edge->GetStreetNameOffset(i);
+  for (uint32_t i = 0; i < edge->name_count(); i++) {
+    uint32_t offset = edge->GetStreetNameOffset(i);
     if (offset < textlist_size_) {
       names.push_back(textlist_ + offset);
     } else {

--- a/src/baldr/graphtile.cc
+++ b/src/baldr/graphtile.cc
@@ -22,6 +22,15 @@ namespace {
         return "\03";
     }
   };
+  template <class numeric_t>
+  size_t digits(numeric_t number) {
+    size_t digits = (number < 0 ? 1 : 0);
+    while (static_cast<long long int>(number)) {
+        number /= 10;
+        digits++;
+    }
+    return digits;
+  }
 }
 
 namespace valhalla {
@@ -113,7 +122,7 @@ std::string GraphTile::FileSuffix(const GraphId& graphid, const TileHierarchy& h
 
   //figure out how many digits
   //TODO: dont convert it to a string to get the length there are faster ways..
-  size_t max_length = std::to_string(max_id).length();
+  size_t max_length = digits<uint32_t>(max_id);
   size_t remainder = max_length % 3;
   if(remainder)
     max_length += 3 - remainder;

--- a/test/graphtile.cc
+++ b/test/graphtile.cc
@@ -36,7 +36,7 @@ void TestFileSuffix() {
   if(GraphTile::FileSuffix(GraphId(64799, 1, 0), h) != "1/064/799.gph")
     throw std::runtime_error("Unexpected graphtile suffix");
 
-  if(GraphTile::FileSuffix(GraphId(4049, 0, 0), h) != "0/004/049.gph")
+  if(GraphTile::FileSuffix(GraphId(49, 0, 0), h) != "0/000/049.gph")
     throw std::runtime_error("Unexpected graphtile suffix");
 }
 

--- a/test/graphtile.cc
+++ b/test/graphtile.cc
@@ -1,0 +1,51 @@
+#include "test.h"
+
+#include "baldr/graphtile.h"
+
+using namespace std;
+using namespace valhalla::baldr;
+
+namespace {
+
+void TestFileSuffix() {
+  std::stringstream json; json << "\
+  {\
+    \"output\": {\
+      \"tile_dir\": \"/data/valhalla\",\
+      \"levels\": [\
+        {\"name\": \"local\", \"level\": 2, \"size\": 0.25},\
+        {\"name\": \"highway\", \"level\": 0, \"size\": 4},\
+        {\"name\": \"arterial\", \"level\": 1, \"size\": 1, \"importance_cutoff\": \"Trunk\"}\
+      ]\
+    }\
+  }";
+
+  boost::property_tree::ptree pt;
+  boost::property_tree::read_json(json, pt);
+  TileHierarchy h(pt);
+
+  if(GraphTile::FileSuffix(GraphId(2, 2, 0), h) != "2/000/000/002.gph")
+    throw std::runtime_error("Unexpected graphtile suffix");
+
+  if(GraphTile::FileSuffix(GraphId(4, 2, 0), h) != "2/000/000/004.gph")
+    throw std::runtime_error("Unexpected graphtile suffix");
+
+  if(GraphTile::FileSuffix(GraphId(6897468, 2, 0), h) != "2/006/897/468.gph")
+    throw std::runtime_error("Unexpected graphtile suffix");
+
+  if(GraphTile::FileSuffix(GraphId(64799, 1, 0), h) != "1/064/799.gph")
+    throw std::runtime_error("Unexpected graphtile suffix");
+
+  if(GraphTile::FileSuffix(GraphId(4049, 0, 0), h) != "0/004/049.gph")
+    throw std::runtime_error("Unexpected graphtile suffix");
+}
+
+}
+
+int main() {
+  test::suite suite("graphtile");
+
+  suite.test(TEST_CASE(TestFileSuffix));
+
+  return suite.tear_down();
+}

--- a/valhalla/baldr/graphtile.h
+++ b/valhalla/baldr/graphtile.h
@@ -6,6 +6,7 @@
 #include <valhalla/baldr/directededge.h>
 #include <valhalla/baldr/nodeinfo.h>
 #include <valhalla/baldr/edgeinfo.h>
+#include <valhalla/baldr/tilehierarchy.h>
 
 #include <boost/shared_array.hpp>
 #include <memory>
@@ -28,7 +29,7 @@ class GraphTile {
    * Constructor given a GraphId. Reads the graph tile from file
    * into memory.
    */
-  GraphTile(const std::string& basedirectory, const GraphId& graphid);
+  GraphTile(const TileHierarchy& hierarchy, const GraphId& graphid);
 
   /**
    * Destructor
@@ -36,21 +37,12 @@ class GraphTile {
   virtual ~GraphTile();
 
   /**
-   * Gets the filename given the graphId
+   * Gets the directory like filename suffix given the graphId
    * @param  graphid  Graph Id to construct filename.
-   * @param  basedirectory  Base data directory
-   * @return  Returns filename (including directory path relative to tile
-   *          base directory
+   * @param  heirarchy The tile hierarchy structure to get info about how many tiles can exist at this level
+   * @return  Returns a filename including directory path as a suffix to be appended to another uri
    */
-  static std::string Filename(const std::string& basedirectory,
-                       const GraphId& graphid);
-
-  /**
-   * Gets the directory to a given tile.
-   * @param  graphid  Graph Id to construct file directory.
-   * @return  Returns file directory path relative to tile base directory
-   */
-  static std::string FileDirectory(const GraphId& graphid);
+  static std::string FileSuffix(const GraphId& graphid, const TileHierarchy& heirarchy);
 
   /**
    * Gets the size of the tile in bytes. A value of 0 indicates an empty tile. A value

--- a/valhalla/baldr/graphtile.h
+++ b/valhalla/baldr/graphtile.h
@@ -39,10 +39,10 @@ class GraphTile {
   /**
    * Gets the directory like filename suffix given the graphId
    * @param  graphid  Graph Id to construct filename.
-   * @param  heirarchy The tile hierarchy structure to get info about how many tiles can exist at this level
+   * @param  hierarchy The tile hierarchy structure to get info about how many tiles can exist at this level
    * @return  Returns a filename including directory path as a suffix to be appended to another uri
    */
-  static std::string FileSuffix(const GraphId& graphid, const TileHierarchy& heirarchy);
+  static std::string FileSuffix(const GraphId& graphid, const TileHierarchy& hierarchy);
 
   /**
    * Gets the size of the tile in bytes. A value of 0 indicates an empty tile. A value
@@ -112,8 +112,7 @@ class GraphTile {
   /**
    * Convenience method to get the names for an edge.
    */
-  std::vector<std::string>& GetNames(const uint32_t edgeinfo_offset,
-                 std::vector<std::string>& names);
+  std::vector<std::string> GetNames(const uint32_t edgeinfo_offset);
 
  protected:
   // Size of the tile in bytes


### PR DESCRIPTION
this makes it so that tiles will be written only 1000 at a time to any single dir and that no dir has no more than 1000 other dirs in it. there is  a test against this as well.

it also does a little clean up of shared pointer stuff and the GetNames function

this breaks mjolnir and thor, prs in the hopper