### PR TITLE
New exit list logic.

### DIFF
--- a/src/baldr/directededge.cc
+++ b/src/baldr/directededge.cc
@@ -26,9 +26,9 @@ GraphId DirectedEdge::endnode() const {
 
 // ------------------  Data offsets and flags for extended data -------------//
 
-// Get the offset to the common edge data.
-uint32_t DirectedEdge::edgedataoffset() const {
-  return dataoffsets_.edgedataoffset;
+// Get the offset to the common edge information.
+uint32_t DirectedEdge::edgeinfo_offset() const {
+  return dataoffsets_.edgeinfo_offset;
 }
 
 // Does this directed edge have exit information.
@@ -186,8 +186,8 @@ const uint64_t DirectedEdge::internal_version() {
   de.classification_ = {};
 
   // DataOffsets
-  de.dataoffsets_.edgedataoffset = ~de.dataoffsets_.edgedataoffset;
-  boost::hash_combine(seed, ffs(de.dataoffsets_.edgedataoffset+1)-1);
+  de.dataoffsets_.edgeinfo_offset = ~de.dataoffsets_.edgeinfo_offset;
+  boost::hash_combine(seed, ffs(de.dataoffsets_.edgeinfo_offset+1)-1);
   de.dataoffsets_.spare = ~de.dataoffsets_.spare;
   boost::hash_combine(seed, ffs(de.dataoffsets_.spare+1)-1);
   de.dataoffsets_.exit = ~de.dataoffsets_.exit;

--- a/src/baldr/directededge.cc
+++ b/src/baldr/directededge.cc
@@ -6,7 +6,7 @@ namespace baldr {
 
 // Default constructor
 DirectedEdge::DirectedEdge()
-    : edgedataoffset_(0),
+    : dataoffsets_{},
       geoattributes_{},
       forwardaccess_{},
       reverseaccess_{},
@@ -24,9 +24,16 @@ GraphId DirectedEdge::endnode() const {
   return endnode_;
 }
 
+// ------------------  Data offsets and flags for extended data -------------//
+
 // Get the offset to the common edge data.
 uint32_t DirectedEdge::edgedataoffset() const {
-  return edgedataoffset_;
+  return dataoffsets_.edgedataoffset;
+}
+
+// Does this directed edge have exit information.
+bool DirectedEdge::exit() const {
+  return dataoffsets_.exit;
 }
 
 // Gets the length of the edge in meters.
@@ -34,15 +41,15 @@ uint32_t DirectedEdge::length() const {
   return geoattributes_.length;
 }
 
-/**
-  * Gets the intersection internal flag.
-  * @return  Returns true if the edge is internal to an intersection. This
-  *          is derived from OSM and used for doubly digitized intersections.
-  */
-bool DirectedEdge::internal() const {
-  return geoattributes_.internal;
+// Gets the elevation factor (0-15).
+uint32_t DirectedEdge::elevation() const {
+  return geoattributes_.elevation;
 }
 
+// Gets the lane count
+uint32_t DirectedEdge::lanecount() const {
+  return geoattributes_.lanecount;
+}
 
 // Get the access modes in the forward direction (bit field).
 uint8_t DirectedEdge::forwardaccess() const {
@@ -61,6 +68,21 @@ uint8_t DirectedEdge::speed() const {
 
 // TODO - methods for individual access
 
+// Get the road class / importance.
+RoadClass DirectedEdge::importance() const {
+  return static_cast<RoadClass>(classification_.importance);
+}
+
+// Is this edge a link / ramp?
+bool DirectedEdge::link() const {
+  return classification_.link;
+}
+
+// Get the use of this edge.
+Use DirectedEdge::use() const {
+  return static_cast<Use>(classification_.use);
+}
+
 bool DirectedEdge::ferry() const {
   return attributes_.ferry;
 }
@@ -71,10 +93,6 @@ bool DirectedEdge::railferry() const {
 
 bool DirectedEdge::toll() const {
   return attributes_.toll;
-}
-
-bool DirectedEdge::exit() const {
-  return attributes_.exit;
 }
 
 bool DirectedEdge::destonly() const {
@@ -105,11 +123,6 @@ Surface DirectedEdge::surface() const {
 // Get the cycle lane of this edge.
 CycleLane DirectedEdge::cyclelane() const {
   return static_cast<CycleLane>(attributes_.cycle_lane);
-}
-
-// Gets the lane count
-uint32_t DirectedEdge::lanecount() const {
-  return attributes_.lanecount;
 }
 
 // Does this edge represent a transition up one level in the hierarchy.
@@ -154,27 +167,17 @@ uint32_t DirectedEdge::bikenetwork() const {
   return attributes_.bikenetwork;
 }
 
-// Get the road class / importance.
-RoadClass DirectedEdge::importance() const {
-  return static_cast<RoadClass>(classification_.importance);
-}
-
-// Is this edge a link / ramp?
-bool DirectedEdge::link() const {
-  return classification_.link;
-}
-
-// Get the use of this edge.
-Use DirectedEdge::use() const {
-  return static_cast<Use>(classification_.use);
+// Gets the intersection internal flag.
+bool DirectedEdge::internal() const {
+  return attributes_.internal;
 }
 
 // Get the internal version
 const uint64_t DirectedEdge::internal_version() {
+  uint64_t seed = 0;
 
   DirectedEdge de;
-
-  de.edgedataoffset_ = 0;
+  de.dataoffsets_ = {};
   de.geoattributes_ = {};
   de.forwardaccess_ = {};
   de.reverseaccess_ = {};
@@ -182,17 +185,23 @@ const uint64_t DirectedEdge::internal_version() {
   de.attributes_ = {};
   de.classification_ = {};
 
-  uint64_t seed = 0;
+  // DataOffsets
+  de.dataoffsets_.edgedataoffset = ~de.dataoffsets_.edgedataoffset;
+  boost::hash_combine(seed, ffs(de.dataoffsets_.edgedataoffset+1)-1);
+  de.dataoffsets_.spare = ~de.dataoffsets_.spare;
+  boost::hash_combine(seed, ffs(de.dataoffsets_.spare+1)-1);
+  de.dataoffsets_.exit = ~de.dataoffsets_.exit;
+  boost::hash_combine(seed, ffs(de.dataoffsets_.exit+1)-1);
 
-  boost::hash_combine(seed,de.edgedataoffset_);
-
+  // GeoAttributes
   de.geoattributes_.length = ~de.geoattributes_.length;
   boost::hash_combine(seed,ffs(de.geoattributes_.length+1)-1);
   de.geoattributes_.elevation = ~de.geoattributes_.elevation;
   boost::hash_combine(seed,ffs(de.geoattributes_.elevation+1)-1);
-  de.geoattributes_.spare = ~de.geoattributes_.spare;
-  boost::hash_combine(seed,ffs(de.geoattributes_.spare+1)-1);
+  de.geoattributes_.lanecount = ~de.geoattributes_.lanecount;
+  boost::hash_combine(seed,ffs(de.geoattributes_.lanecount+1)-1);
 
+  // Access
   de.forwardaccess_.fields.pedestrian  = ~de.forwardaccess_.fields.pedestrian;
   boost::hash_combine(seed,ffs(de.forwardaccess_.fields.pedestrian+1)-1);
   de.forwardaccess_.fields.bicycle  = ~de.forwardaccess_.fields.bicycle;
@@ -210,8 +219,10 @@ const uint64_t DirectedEdge::internal_version() {
   de.forwardaccess_.fields.truck  = ~de.forwardaccess_.fields.truck;
   boost::hash_combine(seed,ffs(de.forwardaccess_.fields.truck+1)-1);
 
+  // Speed
   boost::hash_combine(seed,de.speed_);
 
+  // Classification
   de.classification_.importance = ~de.classification_.importance;
   boost::hash_combine(seed,ffs(de.classification_.importance+1)-1);
   de.classification_.link = ~de.classification_.link;
@@ -219,6 +230,7 @@ const uint64_t DirectedEdge::internal_version() {
   de.classification_.use = ~de.classification_.use;
   boost::hash_combine(seed,ffs(de.classification_.use+1)-1);
 
+  // Attributes
   de.attributes_.bikenetwork = ~de.attributes_.bikenetwork;
   boost::hash_combine(seed,ffs(de.attributes_.bikenetwork+1)-1);
   de.attributes_.bridge = ~de.attributes_.bridge;
@@ -231,8 +243,6 @@ const uint64_t DirectedEdge::internal_version() {
   boost::hash_combine(seed,ffs(de.attributes_.ferry+1)-1);
   de.attributes_.forward = ~de.attributes_.forward;
   boost::hash_combine(seed,ffs(de.attributes_.forward+1)-1);
-  de.attributes_.lanecount = ~de.attributes_.lanecount;
-  boost::hash_combine(seed,ffs(de.attributes_.lanecount+1)-1);
   de.attributes_.not_thru = ~de.attributes_.not_thru;
   boost::hash_combine(seed,ffs(de.attributes_.not_thru+1)-1);
   de.attributes_.opp_index = ~de.attributes_.opp_index;
@@ -243,8 +253,6 @@ const uint64_t DirectedEdge::internal_version() {
   boost::hash_combine(seed,ffs(de.attributes_.roundabout+1)-1);
   de.attributes_.shortcut = ~de.attributes_.shortcut;
   boost::hash_combine(seed,ffs(de.attributes_.shortcut+1)-1);
-  de.attributes_.exit = ~de.attributes_.exit;
-  boost::hash_combine(seed,ffs(de.attributes_.exit+1)-1);
   de.attributes_.superseded = ~de.attributes_.superseded;
   boost::hash_combine(seed,ffs(de.attributes_.superseded+1)-1);
   de.attributes_.surface = ~de.attributes_.surface;
@@ -257,6 +265,8 @@ const uint64_t DirectedEdge::internal_version() {
   boost::hash_combine(seed,ffs(de.attributes_.trans_up+1)-1);
   de.attributes_.tunnel = ~de.attributes_.tunnel;
   boost::hash_combine(seed,ffs(de.attributes_.tunnel+1)-1);
+  de.attributes_.internal = ~de.attributes_.internal;
+  boost::hash_combine(seed,ffs(de.attributes_.internal+1)-1);
 
   boost::hash_combine(seed,sizeof(DirectedEdge));
 

--- a/src/baldr/graphtileheader.cc
+++ b/src/baldr/graphtileheader.cc
@@ -5,6 +5,8 @@
 #include "baldr/edgeinfo.h"
 #include "config.h"
 
+using namespace valhalla::baldr;
+
 namespace valhalla {
 namespace baldr {
 
@@ -14,13 +16,16 @@ namespace baldr {
 // a tile.
 GraphTileHeader::GraphTileHeader()
     : date_created_{},
+      graphid_{},
       nodecount_(0),
       directededgecount_(0),
       edgeinfo_offset_(0),
       textlist_offset_(0),
       exitlist_offset_(0),
       admin_offset_(0),
-      merlist_offset_(0) {
+      merlist_offset_(0),
+      timedres_offset_(0),
+      transit_offset_(0) {
   internal_version_ = NodeInfo::internal_version() +
                       DirectedEdge::internal_version() +
                       GraphId::internal_version();
@@ -41,6 +46,11 @@ uint64_t GraphTileHeader::date_created() const {
 // Get the version string.
 std::string GraphTileHeader::version() const {
   return version_;
+}
+
+// Get the GraphId (tileid and level) of this tile.
+const GraphId& GraphTileHeader::graphid() const {
+  return graphid_;
 }
 
 // Get the count of nodes in the tile.

--- a/valhalla/baldr/directededge.h
+++ b/valhalla/baldr/directededge.h
@@ -23,6 +23,9 @@ constexpr uint8_t kRcn = 2;   // Part of regional bike network
 constexpr uint8_t kLcn = 4;   // Part of local bike network
 constexpr uint8_t kMcn = 8;   // Part of mountain bike network
 
+// Maximum offset to edge information
+constexpr uint32_t kMaxEdgeInfoOffset = 16777215;   // 2^24 bytes
+
 // Maximum length of an edge
 constexpr uint32_t kMaxEdgeLength = 16777215;   // 2^24 meters
 
@@ -55,17 +58,29 @@ class DirectedEdge {
   uint32_t edgedataoffset() const;
 
   /**
+   * Does this directed edge have exit information?
+   * @return  Returns true if the directed edge has exit information,
+   *          false if not.
+   */
+  bool exit() const;
+
+  /**
    * Gets the length of the edge in meters.
    * @return  Returns the length in meters.
    */
   uint32_t length() const;
 
   /**
-   * Gets the intersection internal flag.
-   * @return  Returns true if the edge is internal to an intersection. This
-   *          is derived from OSM and used for doubly digitized intersections.
+   * Get the elevation factor.  TODO
+   * @return  Returns the elevation factor (0-15).
    */
-  bool internal() const;
+  uint32_t elevation() const;
+
+  /**
+   * Get the number of lanes for this directed edge.
+   * @return  Returns the number of lanes for this directed edge.
+   */
+  uint32_t lanecount() const;
 
   /**
    * Get the access modes in the forward direction (bit field).
@@ -84,6 +99,22 @@ class DirectedEdge {
   uint8_t speed() const;
 
   /**
+   * Get the importance of the road/path
+   * @return  Returns importance / RoadClass
+   */
+  RoadClass importance() const;
+
+  /**
+   * Is this edge a link/ramp?
+   */
+  bool link() const;
+
+  /**
+   * Get the use of this edge.
+   */
+  Use use() const;
+
+  /**
    * Is this edge part of a ferry?
    */
   bool ferry() const;
@@ -97,11 +128,6 @@ class DirectedEdge {
    * Does this edge have a toll or is it part of a toll road?
    */
   bool toll() const;
-
-  /**
-   * Does this edge have a exit?
-   */
-  bool exit() const;
 
   /**
    * Is this edge part of a private or no through road that allows access
@@ -208,26 +234,11 @@ class DirectedEdge {
   uint32_t bikenetwork() const;
 
   /**
-   * Get the number of lanes for this directed edge.
-   * @return  Returns the number of lanes for this directed edge.
+   * Gets the intersection internal flag.
+   * @return  Returns true if the edge is internal to an intersection. This
+   *          is derived from OSM and used for doubly digitized intersections.
    */
-  uint32_t lanecount() const;
-
-  /**
-   * Get the importance of the road/path
-   * @return  Returns importance / RoadClass
-   */
-  RoadClass importance() const;
-
-  /**
-   * Is this edge a link/ramp?
-   */
-  bool link() const;
-
-  /**
-   * Get the use of this edge.
-   */
-  Use use() const;
+  bool internal() const;
 
   /**
    * Get the computed version of DirectedEdge attributes.
@@ -239,15 +250,19 @@ class DirectedEdge {
   // End node
   GraphId endnode_;
 
-  // Offset to the common edge data within the tile
-  uint32_t edgedataoffset_;
+  // Data offsets and flags for extended data.
+  struct DataOffsets {
+    uint32_t edgedataoffset : 24; // Offset to edge data.
+    uint32_t spare          :  7;
+    uint32_t exit           :  1; // Does this directed edge have exits
+  };
+  DataOffsets dataoffsets_;
 
-  // Geometric attributes: length, elevation factor.
+  // Geometric attributes: length, elevation factor, lane count.
   struct GeoAttributes {
     uint32_t length        : 24;  // Length in meters
-    uint32_t elevation     : 4;   // Elevation factor
-    uint32_t internal      : 1;   // Edge that is internal to an intersection
-    uint32_t spare         : 3;
+    uint32_t elevation     :  4;  // Elevation factor
+    uint32_t lanecount     :  4;  // Number of lanes
   };
   GeoAttributes geoattributes_;
 
@@ -289,7 +304,7 @@ class DirectedEdge {
     uint32_t railferry      : 1;
     uint32_t toll           : 1;
     uint32_t dest_only      : 1;
-    uint32_t exit           : 1;
+    uint32_t spare          : 1;
     uint32_t tunnel         : 1;
     uint32_t bridge         : 1;
     uint32_t roundabout     : 1;
@@ -304,7 +319,9 @@ class DirectedEdge {
     uint32_t not_thru       : 1;  // Edge leads to "no-through" region
     uint32_t opp_index      : 5;  // Opposing directed edge index
     uint32_t bikenetwork    : 4;
-    uint32_t lanecount      : 4;
+    uint32_t internal       : 1;  // Edge that is internal to an intersection
+    uint32_t spare2         : 3;
+
   };
   Attributes attributes_;
 

--- a/valhalla/baldr/directededge.h
+++ b/valhalla/baldr/directededge.h
@@ -52,10 +52,10 @@ class DirectedEdge {
 
   /**
    * Offset to the common edge data. The offset is from the start
-   * of the common edge data within a tile.
-   * @return  Returns offset from the start of the edge data within a tile.
+   * of the common edge information  within a tile.
+   * @return  Returns offset from the start of the edge info within a tile.
    */
-  uint32_t edgedataoffset() const;
+  uint32_t edgeinfo_offset() const;
 
   /**
    * Does this directed edge have exit information?
@@ -252,9 +252,9 @@ class DirectedEdge {
 
   // Data offsets and flags for extended data.
   struct DataOffsets {
-    uint32_t edgedataoffset : 24; // Offset to edge data.
-    uint32_t spare          :  7;
-    uint32_t exit           :  1; // Does this directed edge have exits
+    uint32_t edgeinfo_offset : 24; // Offset to edge data.
+    uint32_t spare           :  7;
+    uint32_t exit            :  1; // Does this directed edge have exits
   };
   DataOffsets dataoffsets_;
 

--- a/valhalla/baldr/graphtile.h
+++ b/valhalla/baldr/graphtile.h
@@ -119,6 +119,7 @@ class GraphTile {
   std::vector<std::string> GetNames(const uint32_t edgeinfo_offset) const;
 
   /**
+   * TODO - delete this method once new one is working...
    * Convenience method to get the exit signs for an edge given the offset to the
    * edge information.
    * @param  edgeinfo_offset  Offset to the edge info.
@@ -126,12 +127,36 @@ class GraphTile {
    */
   std::vector<ExitSignInfo> GetExitSigns(const uint32_t edgeinfo_offset) const;
 
+  /**
+   * Convenience method to get the exit signs for an edge given the offset to the
+   * edge information.
+   * @param  idx  Directed edge index. Used to lookup list of exit signs.
+   * @return  Returns a list (vector) of exit signs.
+   */
+  std::vector<ExitSignInfo> GetExitSignList(const uint32_t idx);
+
  protected:
+  // Internal exit list
+  struct InternalExit {
+    uint32_t     idx;
+    ExitSignInfo sign;
+
+    InternalExit(const uint32_t n, const ExitSignInfo& s)
+        : idx(n),
+          sign(s) {
+    }
+
+    // Compare by idx
+    bool operator< (const InternalExit& other) const {
+      return idx < other.idx;
+    }
+  };
+
   // Size of the tile in bytes
   size_t size_;
 
   // Graph tile memory, this must be shared so that we can put it into cache
-  // Aparently you can std::move a non-copyable
+  // Apparently you can std::move a non-copyable
   boost::shared_array<char> graphtile_;
 
   // Header information for the tile
@@ -152,15 +177,25 @@ class GraphTile {
   // Size of the edgeinfo data
   std::size_t edgeinfo_size_;
 
-  // Street names and exit names/numbers as sets of null-terminated char arrays.
-  // Edge info has offsets into this array.
+  // Street names as sets of null-terminated char arrays. Edge info has
+  // offsets into this array.
   char* textlist_;
 
   // Number of bytes in the text/name list
   std::size_t textlist_size_;
 
+  // Exit information. Lookup by the directed edge index.
+  bool exitlist_created_;
+  std::vector<InternalExit> exitlist_;
+
   // The id of the tile for convenience
   const GraphId id_;
+
+  /**
+   * Creates a vector of exit sign information that can be access via the
+   * directed edge index.
+   */
+  void CreateExitList();
 };
 
 }

--- a/valhalla/baldr/graphtileheader.h
+++ b/valhalla/baldr/graphtileheader.h
@@ -4,6 +4,8 @@
 #include <cstdlib>
 #include <string>
 
+#include <valhalla/baldr/graphid.h>
+
 namespace valhalla {
 namespace baldr {
 
@@ -40,6 +42,12 @@ class GraphTileHeader {
    * @return  Returns the version of this tile.
    */
   std::string version() const;
+
+  /**
+   * Get the GraphId (tileid and level) of this tile.
+   * @return  Returns the graph Id.
+   */
+  const baldr::GraphId& graphid() const;
 
   /**
    * Gets the number of nodes in this tile.
@@ -109,6 +117,9 @@ class GraphTileHeader {
 
   // baldr version.
   char version_[kMaxVersionSize];
+
+  // GraphId (tileid and level) of this tile
+  GraphId graphid_;
 
   // Number of nodes
   uint32_t nodecount_;


### PR DESCRIPTION
Added GraphId to the GraphTileHeader.
This is a new GetExitSignList method. When it is working the existing exit sign logic (with exits stored on EdgeInfo) will be removed.