### PR TITLE
Move exit signs to be separate entity 

### DIFF
--- a/src/baldr/edgeinfo.cc
+++ b/src/baldr/edgeinfo.cc
@@ -16,9 +16,6 @@ EdgeInfo::EdgeInfo(char* ptr, const char* names_list, const size_t names_list_le
   // Set encoded_shape_ pointer
   encoded_shape_ = ptr;
   ptr += (encoded_shape_size() * sizeof(char));
-
-  // Set exit_signs_ pointer
-  exit_signs_ = reinterpret_cast<ExitSign*>(ptr);
 }
 
 EdgeInfo::~EdgeInfo() {
@@ -34,22 +31,11 @@ const uint32_t EdgeInfo::encoded_shape_size() const {
   return item_->fields.encoded_shape_size ;
 }
 
-const uint32_t EdgeInfo::exit_sign_count() const {
-  return item_->fields.exit_sign_count;
-}
-
 const uint32_t EdgeInfo::GetStreetNameOffset(uint8_t index) const {
   if(index < item_->fields.name_count)
     return street_name_offset_list_[index];
   else
     throw std::runtime_error("StreetNameOffset index was out of bounds");
-}
-
-const ExitSign* EdgeInfo::GetExitSign(uint8_t index) const {
-  if(index < item_->fields.exit_sign_count)
-    return (exit_signs_ + index);
-  else
-    throw std::runtime_error("ExitSign index was out of bounds");
 }
 
 const std::vector<std::string> EdgeInfo::GetNames() const {
@@ -64,21 +50,6 @@ const std::vector<std::string> EdgeInfo::GetNames() const {
     }
   }
   return names;
-}
-
-std::vector<ExitSignInfo> EdgeInfo::GetExitSigns() const {
-  // Get each exit sign
-  std::vector<ExitSignInfo> exit_list;
-  for (uint32_t i = 0; i < exit_sign_count(); i++) {
-    const ExitSign* exit_sign = GetExitSign(i);
-    if (exit_sign->text_offset() < names_list_length_) {
-      exit_list.emplace_back(
-          exit_sign->type(), (names_list_ + exit_sign->text_offset()));
-    } else {
-      throw std::runtime_error("GetExitSigns: offset exceeds size of text list");
-    }
-  }
-  return exit_list;
 }
 
 const std::vector<PointLL>& EdgeInfo::shape() const {

--- a/src/baldr/exitsign.cc
+++ b/src/baldr/exitsign.cc
@@ -17,12 +17,12 @@ uint32_t ExitSign::edgeindex() const {
 }
 
 // Get the exit sign type.
-const ExitSign::Type& ExitSign::type() const {
+ExitSign::Type ExitSign::type() const {
   return type_;
 }
 
 // Get the offset within the text/names list for the sign text.
-const uint32_t ExitSign::text_offset() const {
+uint32_t ExitSign::text_offset() const {
   return text_offset_;
 }
 

--- a/src/baldr/exitsign.cc
+++ b/src/baldr/exitsign.cc
@@ -3,17 +3,27 @@
 namespace valhalla {
 namespace baldr {
 
+// Constructor given parameters.
+ExitSign::ExitSign(const uint32_t idx, const ExitSign::Type& type,
+                   const uint32_t text_offset)
+    : edgeindex_(idx),
+      type_(type),
+      text_offset_(text_offset) {
+}
+
+// Get the directed edge index to which this sign applies.
+uint32_t ExitSign::edgeindex() const {
+  return edgeindex_;
+}
+
+// Get the exit sign type.
 const ExitSign::Type& ExitSign::type() const {
   return type_;
 }
 
+// Get the offset within the text/names list for the sign text.
 const uint32_t ExitSign::text_offset() const {
   return text_offset_;
-}
-
-ExitSign::ExitSign(const ExitSign::Type& type, uint32_t text_offset)
-    : type_(type),
-      text_offset_(text_offset) {
 }
 
 }

--- a/src/baldr/graphtileheader.cc
+++ b/src/baldr/graphtileheader.cc
@@ -19,9 +19,9 @@ GraphTileHeader::GraphTileHeader()
       graphid_{},
       nodecount_(0),
       directededgecount_(0),
+      exitsigncount_(0),
       edgeinfo_offset_(0),
       textlist_offset_(0),
-      exitlist_offset_(0),
       admin_offset_(0),
       merlist_offset_(0),
       timedres_offset_(0),
@@ -63,6 +63,11 @@ uint32_t GraphTileHeader::directededgecount() const {
   return directededgecount_;
 }
 
+// Gets the number of exit signs in the tile.
+uint32_t GraphTileHeader::exitsigncount() const {
+  return exitsigncount_;
+}
+
 // Get the offset in bytes to the start of the edge information.
 uint32_t GraphTileHeader::edgeinfo_offset() const {
   return edgeinfo_offset_;
@@ -71,11 +76,6 @@ uint32_t GraphTileHeader::edgeinfo_offset() const {
 // Get the offset in bytes to the start of the text / names list.
 uint32_t GraphTileHeader::textlist_offset() const {
   return textlist_offset_;
-}
-
-// Gets the offset in bytes to the exit list.
-uint32_t GraphTileHeader::exitlist_offset() const {
-  return exitlist_offset_;
 }
 
 // Get the offset in bytes to the administrative information. (TODO)

--- a/valhalla/baldr/edgeinfo.h
+++ b/valhalla/baldr/edgeinfo.h
@@ -9,8 +9,6 @@
 #include <valhalla/midgard/pointll.h>
 #include <valhalla/midgard/util.h>
 #include <valhalla/baldr/graphid.h>
-#include <valhalla/baldr/exitsign.h>
-#include <valhalla/baldr/exitsigninfo.h>
 
 using namespace valhalla::midgard;
 
@@ -22,7 +20,6 @@ constexpr size_t kMaxEncodedShapeSize = 16383;
 /**
  * Edge information not required in shortest path algorithm and is
  * common among the 2 directions.
- * @author  David W. Nesbitt
  */
 class EdgeInfo {
  public:
@@ -48,26 +45,14 @@ class EdgeInfo {
   // Returns the shape count
   const uint32_t encoded_shape_size() const;
 
-  // Returns the exit sign count
-  const uint32_t exit_sign_count() const;
-
   // Returns the name index at the specified index.
   const uint32_t GetStreetNameOffset(uint8_t index) const;
-
-  // Returns an exit sign pointer at the specified index.
-  const ExitSign* GetExitSign(uint8_t index) const;
 
   /**
    * Convenience method to get the names for an edge
    * @return   Returns a list (vector) of names.
    */
   const std::vector<std::string> GetNames() const;
-
-  /**
-   * Convenience method to get the exit signs for an edge
-   * @return   Returns a list (vector) of exit signs.
-   */
-  std::vector<ExitSignInfo> GetExitSigns() const;
 
   /**
    * Get the shape of the edge.
@@ -83,10 +68,9 @@ class EdgeInfo {
   union PackedItem {
     struct Fields {
 
-      uint32_t name_count                     :4;
-      uint32_t encoded_shape_size             :14;
-      uint32_t exit_sign_count                :4;
-      uint32_t spare                          :10;
+      uint32_t name_count          :4;
+      uint32_t encoded_shape_size  :14;
+      uint32_t spar                :14;
     } fields;
     uint32_t value;
   };
@@ -102,9 +86,6 @@ class EdgeInfo {
 
   // The encoded shape of the edge
   mutable char* encoded_shape_;
-
-  // List of exit signs (type and index)
-  ExitSign* exit_signs_;
 
   // Lng, lat shape of the edge
   mutable std::vector<PointLL> shape_;

--- a/valhalla/baldr/exitsign.h
+++ b/valhalla/baldr/exitsign.h
@@ -21,6 +21,13 @@ class ExitSign {
     kName
   };
 
+  /**
+   * Get the index of the directed edge this exit sign applies to.
+   * @return  Returns the directed edge index (within the same tile
+   *          as the exit information).
+   */
+  uint32_t edgeindex() const;
+
   // Returns the exit sign type
   const ExitSign::Type& type() const;
 
@@ -29,8 +36,10 @@ class ExitSign {
 
  protected:
   // Constructor
-  ExitSign(const ExitSign::Type& type, uint32_t text_offset);
+  ExitSign(const uint32_t idx, const ExitSign::Type& type,
+           const uint32_t text_offset);
 
+  uint32_t edgeindex_;
   ExitSign::Type type_;
   uint32_t text_offset_;
 };

--- a/valhalla/baldr/exitsign.h
+++ b/valhalla/baldr/exitsign.h
@@ -29,10 +29,10 @@ class ExitSign {
   uint32_t edgeindex() const;
 
   // Returns the exit sign type
-  const ExitSign::Type& type() const;
+  ExitSign::Type type() const;
 
   // Returns the text index
-  const uint32_t text_offset() const;
+  uint32_t text_offset() const;
 
  protected:
   // Constructor

--- a/valhalla/baldr/graphtile.h
+++ b/valhalla/baldr/graphtile.h
@@ -29,6 +29,8 @@ class GraphTile {
   /**
    * Constructor given a GraphId. Reads the graph tile from file
    * into memory.
+   * @param  hierarchy  Data describing the tiling and hierarchy system.
+   * @param  graphid    GraphId (tileid and level)
    */
   GraphTile(const TileHierarchy& hierarchy, const GraphId& graphid);
 
@@ -49,15 +51,13 @@ class GraphTile {
    * Gets the size of the tile in bytes. A value of 0 indicates an empty tile. A value
    * of 0 indicates an error reading the tile data.
    * or unsuccessful read.
-   *
-   * @return size   the size of the tile in bytes
+   * @return  Returns the size of the tile in bytes.
    */
   size_t size() const;
 
   /**
-   * Gets the id of the *graph tile
-   *
-   * @return id     the graph id of the tile (pointing to the first node)
+   * Gets the id of the graph tile
+   * @return  Returns the graph id of the tile (pointing to the first node)
    */
   GraphId id() const;
 
@@ -119,38 +119,14 @@ class GraphTile {
   std::vector<std::string> GetNames(const uint32_t edgeinfo_offset) const;
 
   /**
-   * TODO - delete this method once new one is working...
-   * Convenience method to get the exit signs for an edge given the offset to the
-   * edge information.
-   * @param  edgeinfo_offset  Offset to the edge info.
-   * @return  Returns a list (vector) of exit signs.
-   */
-  std::vector<ExitSignInfo> GetExitSigns(const uint32_t edgeinfo_offset) const;
-
-  /**
-   * Convenience method to get the exit signs for an edge given the offset to the
-   * edge information.
+   * Convenience method to get the exit signs for an edge given the directed
+   * edge index.
    * @param  idx  Directed edge index. Used to lookup list of exit signs.
    * @return  Returns a list (vector) of exit signs.
    */
-  std::vector<ExitSignInfo> GetExitSignList(const uint32_t idx);
+  std::vector<ExitSignInfo> GetExitSigns(const uint32_t idx) const;
 
  protected:
-  // Internal exit list
-  struct InternalExit {
-    uint32_t     idx;
-    ExitSignInfo sign;
-
-    InternalExit(const uint32_t n, const ExitSignInfo& s)
-        : idx(n),
-          sign(s) {
-    }
-
-    // Compare by idx
-    bool operator< (const InternalExit& other) const {
-      return idx < other.idx;
-    }
-  };
 
   // Size of the tile in bytes
   size_t size_;
@@ -170,6 +146,9 @@ class GraphTile {
   // indexed directly.
   DirectedEdge* directededges_;
 
+  // Exit signs (indexed by directed edge index)
+  ExitSign* exitsigns_;
+
   // List of edge info structures. Since edgeinfo is not fixed size we
   // use offsets in directed edges.
   char* edgeinfo_;
@@ -183,19 +162,6 @@ class GraphTile {
 
   // Number of bytes in the text/name list
   std::size_t textlist_size_;
-
-  // Exit information. Lookup by the directed edge index.
-  bool exitlist_created_;
-  std::vector<InternalExit> exitlist_;
-
-  // The id of the tile for convenience
-  const GraphId id_;
-
-  /**
-   * Creates a vector of exit sign information that can be access via the
-   * directed edge index.
-   */
-  void CreateExitList();
 };
 
 }

--- a/valhalla/baldr/graphtileheader.h
+++ b/valhalla/baldr/graphtileheader.h
@@ -62,6 +62,12 @@ class GraphTileHeader {
  uint32_t directededgecount() const;
 
   /**
+   * Gets the number of exit signs in this tile.
+   * @return  Returns the number of exit signs.
+   */
+  uint32_t exitsigncount() const;
+
+  /**
    * Gets the offset to the edge info.
    * @return  Returns the number of bytes to offset to the edge information.
    */
@@ -72,12 +78,6 @@ class GraphTileHeader {
    * @return  Returns the number of bytes to offset to the text list.
    */
   uint32_t textlist_offset() const;
-
-  /**
-   * Gets the offset to the exit list.
-   * @return  Returns the number of bytes to offset to the exit list.
-   */
-  uint32_t exitlist_offset() const;
 
   /**
    * Get the offset to the administrative information. (TODO)
@@ -127,14 +127,14 @@ class GraphTileHeader {
   // Number of directed edges
   uint32_t directededgecount_;
 
+  // Number of exit signs
+  uint32_t exitsigncount_;
+
   // Offset to edge info
   uint32_t edgeinfo_offset_;
 
   // Offset to name list
   uint32_t textlist_offset_;
-
-  // Offset to exit list
-  uint32_t exitlist_offset_;
 
   // Offset to the administrative information
   uint32_t admin_offset_;


### PR DESCRIPTION
Fixed size so store them after directed edges. Store count rather than offset in GraphTileHeader. Remove exit signs from edgeInfo. Signature of getting exit signs from tile remains the same, but they will be accessed via directed edge index (logic for searching is TBD).