### PR TITLE
avoid allocating memory over  and avoid reallocating containers on expansion

### DIFF
--- a/src/baldr/graphreader.cc
+++ b/src/baldr/graphreader.cc
@@ -10,6 +10,7 @@ namespace baldr {
 
 //this constructor delegates to the other
 GraphReader::GraphReader(const boost::property_tree::ptree& pt):GraphReader(TileHierarchy(pt)) {
+  tilecache_.reserve(32);
 }
 
 GraphReader::GraphReader(const TileHierarchy& th):tile_hierarchy_(th) {

--- a/src/baldr/graphtile.cc
+++ b/src/baldr/graphtile.cc
@@ -33,6 +33,8 @@ namespace {
     }
     return digits;
   }
+  const std::locale dir_locale(std::locale("C"), new dir_facet());
+  const AABB2 world_box(PointLL(-180, -90), PointLL(180, 90));
 }
 
 namespace valhalla {
@@ -129,20 +131,19 @@ std::string GraphTile::FileSuffix(const GraphId& graphid, const TileHierarchy& h
   */
 
   //figure the largest id for this level
-  auto level = hierarchy.levels().find(graphid.level());
+  const auto level = hierarchy.levels().find(graphid.level());
   if(level == hierarchy.levels().end())
     throw std::runtime_error("Could not compute FileSuffix for non-existent level");
-  uint32_t max_id = Tiles::MaxTileId(AABB2(PointLL(-180, -90), PointLL(180, 90)), level->second.tiles.TileSize());
+  const uint32_t max_id = Tiles::MaxTileId(world_box, level->second.tiles.TileSize());
 
   //figure out how many digits
   //TODO: dont convert it to a string to get the length there are faster ways..
   size_t max_length = digits<uint32_t>(max_id);
-  size_t remainder = max_length % 3;
+  const size_t remainder = max_length % 3;
   if(remainder)
     max_length += 3 - remainder;
 
   //make a locale to use as a formatter for numbers
-  std::locale dir_locale(std::locale("C"), new dir_facet());
   std::ostringstream stream;
   stream.imbue(dir_locale);
 

--- a/src/baldr/pathlocation.cc
+++ b/src/baldr/pathlocation.cc
@@ -8,6 +8,7 @@ namespace baldr{
 
   PathLocation::PathLocation(const Location& location):Location(location) {
     node_ = false;
+    edges_.reserve(16);
   }
 
   bool PathLocation::IsNode() const {


### PR DESCRIPTION
these were popping up when checking hot spots with callgrind