### PR TITLE
Add support for simple turn restrictions.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -50,7 +50,8 @@ nobase_include_HEADERS = \
 	valhalla/baldr/pathlocation.h \
 	valhalla/baldr/sign.h \
         valhalla/baldr/signinfo.h \
-	valhalla/baldr/tilehierarchy.h
+	valhalla/baldr/tilehierarchy.h \
+	valhalla/baldr/turnrestriction.h
 libvalhalla_baldr_la_SOURCES = \
 	src/baldr/directededge.cc \
 	src/baldr/edgeinfo.cc \
@@ -63,7 +64,8 @@ libvalhalla_baldr_la_SOURCES = \
 	src/baldr/pathlocation.cc \
 	src/baldr/sign.cc \
         src/baldr/signinfo.cc \
-	src/baldr/tilehierarchy.cc
+	src/baldr/tilehierarchy.cc \
+	src/baldr/turnrestriction.cc
 libvalhalla_baldr_la_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_CPPFLAGS) @BOOST_CPPFLAGS@
 libvalhalla_baldr_la_LIBADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) @BOOST_LDFLAGS@
 

--- a/src/baldr/directededge.cc
+++ b/src/baldr/directededge.cc
@@ -31,6 +31,13 @@ uint32_t DirectedEdge::edgeinfo_offset() const {
   return dataoffsets_.edgeinfo_offset;
 }
 
+// Does this directed edge form the start of a simple turn restriction?
+// These are turn restrictions from one edge to another that apply to
+// all vehicles, at all times.
+bool DirectedEdge::simple_tr() const {
+  return dataoffsets_.simple_tr;
+}
+
 // Does this directed edge have exit signs.
 bool DirectedEdge::exitsign() const {
   return dataoffsets_.exitsign;

--- a/src/baldr/graphtileheader.cc
+++ b/src/baldr/graphtileheader.cc
@@ -20,6 +20,7 @@ GraphTileHeader::GraphTileHeader()
       nodecount_(0),
       directededgecount_(0),
       signcount_(0),
+      turnrestriction_count_(0),
       edgeinfo_offset_(0),
       textlist_offset_(0),
       admin_offset_(0),
@@ -66,6 +67,11 @@ uint32_t GraphTileHeader::directededgecount() const {
 // Gets the number of signs in the tile.
 uint32_t GraphTileHeader::signcount() const {
   return signcount_;
+}
+
+// Gets the number of simple turn restrictions in the tile.
+uint32_t GraphTileHeader::turnrestriction_count() const {
+  return turnrestriction_count_;
 }
 
 // Get the offset in bytes to the start of the edge information.

--- a/src/baldr/turnrestriction.cc
+++ b/src/baldr/turnrestriction.cc
@@ -1,0 +1,30 @@
+#include "../../valhalla/baldr/turnrestriction.h"
+
+namespace valhalla {
+namespace baldr {
+
+// Constructor
+TurnRestriction::TurnRestriction()
+    : data_{},
+      restriction_mask_(0) {
+}
+
+// Get the index of the "from" directed edge for this turn restriction.
+uint32_t TurnRestriction::edgeindex() const {
+  return data_.edgeindex;
+}
+
+// Get the turn restriction type.
+RestrictionType TurnRestriction::type() const {
+  return static_cast<RestrictionType>(data_.type);
+}
+
+// Get the restriction mask. This is a bit mask where bits set to 1 indicate
+// a restricted turn based on index of the outbound directed edge at the
+// end node of this directed edge.
+uint32_t TurnRestriction::restriction_mask() const {
+  return restriction_mask_;
+}
+
+}
+}

--- a/valhalla/baldr/directededge.h
+++ b/valhalla/baldr/directededge.h
@@ -58,6 +58,15 @@ class DirectedEdge {
   uint32_t edgeinfo_offset() const;
 
   /**
+   * Does this directed edge form the start of a simple turn restriction?
+   * These are turn restrictions from one edge to another that apply to
+   * all vehicles, at all times.
+   * @return  Returns true if the directed edge starts a simple turn
+   *          restriction, false if not.
+   */
+  bool simple_tr() const;
+
+  /**
    * Does this directed edge have exit signs?
    * @return  Returns true if the directed edge has exit signs,
    *          false if not.
@@ -253,7 +262,9 @@ class DirectedEdge {
   // Data offsets and flags for extended data.
   struct DataOffsets {
     uint32_t edgeinfo_offset : 24; // Offset to edge data.
-    uint32_t spare           :  7;
+    uint32_t spare           :  6;
+    uint32_t simple_tr       :  1; // Directed edge starts a simple
+                                   // turn restriction
     uint32_t exitsign        :  1; // Does this directed edge have exit signs
   };
   DataOffsets dataoffsets_;

--- a/valhalla/baldr/graphtile.h
+++ b/valhalla/baldr/graphtile.h
@@ -5,6 +5,8 @@
 #include <valhalla/baldr/graphtileheader.h>
 #include <valhalla/baldr/directededge.h>
 #include <valhalla/baldr/nodeinfo.h>
+#include <valhalla/baldr/sign.h>
+#include <valhalla/baldr/turnrestriction.h>
 #include <valhalla/baldr/edgeinfo.h>
 #include <valhalla/baldr/tilehierarchy.h>
 #include <boost/shared_array.hpp>
@@ -16,7 +18,6 @@ namespace baldr {
 
 /**
  * Graph information for a tile within the Tiled Hierarchical Graph.
- * @author  David W. Nesbitt
  */
 class GraphTile {
  public:
@@ -125,6 +126,17 @@ class GraphTile {
    */
   std::vector<SignInfo> GetSigns(const uint32_t idx) const;
 
+  /**
+   * Convenience method to get turn restrictions for an edge given the
+   * directed edge index.
+   * @param  idx  Directed edge index. Used to lookup list of signs.
+   * @param  type (OUT) - Restriction type.
+   * @return  Returns an integer with bits marking which directed edge indexes
+   *          at the end node are restricted from this directed edge.
+   */
+  uint32_t GetTurnRestrictions(const uint32_t idx,
+                               baldr::RestrictionType& type) const;
+
  protected:
 
   // Size of the tile in bytes
@@ -147,6 +159,9 @@ class GraphTile {
 
   // Signs (indexed by directed edge index)
   Sign* signs_;
+
+  // Simple turn restrictions
+  TurnRestriction* turnrestrictions_;
 
   // List of edge info structures. Since edgeinfo is not fixed size we
   // use offsets in directed edges.

--- a/valhalla/baldr/graphtileheader.h
+++ b/valhalla/baldr/graphtileheader.h
@@ -68,6 +68,12 @@ class GraphTileHeader {
   uint32_t signcount() const;
 
   /**
+   * Gets the number of simple turn restrictions in this tile.
+   * @return  Returns the number of turn restrictions.
+   */
+  uint32_t turnrestriction_count() const;
+
+  /**
    * Gets the offset to the edge info.
    * @return  Returns the number of bytes to offset to the edge information.
    */
@@ -129,6 +135,9 @@ class GraphTileHeader {
 
   // Number of signs
   uint32_t signcount_;
+
+  // Number of turn restrictions
+  uint32_t turnrestriction_count_;
 
   // Offset to edge info
   uint32_t edgeinfo_offset_;

--- a/valhalla/baldr/turnrestriction.h
+++ b/valhalla/baldr/turnrestriction.h
@@ -1,0 +1,63 @@
+#ifndef VALHALLA_BALDR_TURNRESTRICTION_H_
+#define VALHALLA_BALDR_TURNRESTRICTION_H_
+
+#include <unordered_map>
+#include <string>
+
+#include <valhalla/baldr/graphconstants.h>
+
+namespace valhalla {
+namespace baldr {
+
+/**
+ * Simple turn restriction. From one directed edge via a node to
+ * other edges from that via node.
+ */
+class TurnRestriction {
+ public:
+  /**
+   * Constructor
+   */
+  TurnRestriction();
+
+  /**
+   * Get the index of the "from" directed edge for this turn restriction.
+   * @return  Returns the directed edge index (within the same tile
+   *          as the turn restriction information).
+   */
+   uint32_t edgeindex() const;
+
+   /**
+    * Get the turn restriction type.
+    * @return  Returns the turn restriction type
+    */
+   RestrictionType type() const;
+
+   /**
+    * Get the restriction mask. This is a bit mask where bits set to 1 indicate
+    * a restricted turn based on index of the outbound directed edge at the
+    * end node of this directed edge.
+    * @return  Returns the restriction mask.
+    */
+   uint32_t restriction_mask() const;
+
+ protected:
+
+  struct IndexAndType {
+    uint32_t edgeindex  : 22;     // kMaxTileEdgeCount in nodeinfo.h: 22 bits
+    uint32_t type       :  4;
+    uint32_t spare      :  6;
+  };
+  IndexAndType data_;
+
+  // Restriction mask. A bit mask where bits set to 1 indicate a restricted
+  // turn based on index of the outbound directed edge at the end node of
+  // this directed edge.
+  uint32_t restriction_mask_;
+};
+
+}
+}
+
+
+#endif  // VALHALLA_BALDR_TURNRESTRICTION_H_


### PR DESCRIPTION
 A flag on the directed edge indicates the start of a simple turn restriction. A bit mask in the turn restriction record (indexed by the directed edge index) indicates the indexes of directed edges at the end node which are restricted. Turn restriction records are fixed size and stored as an array (ordered by the from directed edge index). A binary search is used to access - here there is only one TR record possible for a directed edge (unlike the sign lookup) which simplifies things.