### PR TITLE
Fixes for Asia

### DIFF
--- a/src/baldr/directededge.cc
+++ b/src/baldr/directededge.cc
@@ -339,6 +339,8 @@ const uint64_t DirectedEdge::internal_version() {
   boost::hash_combine(seed,ffs(de.attributes_.restrictions+1)-1);
   de.attributes_.use = ~de.attributes_.use;
   boost::hash_combine(seed,ffs(de.attributes_.use+1)-1);
+  de.attributes_.speed_type = ~de.attributes_.speed_type;
+  boost::hash_combine(seed,ffs(de.attributes_.speed_type+1)-1);
 
   // Access
   de.forwardaccess_.fields.car  = ~de.forwardaccess_.fields.car;

--- a/src/baldr/location.cc
+++ b/src/baldr/location.cc
@@ -23,8 +23,24 @@ namespace baldr{
     if(parts.size() < 2)
       throw std::runtime_error("Bad format for csv formated location");
 
+    // Validate lat,lng input. Longitude must be between -360 and 360. Values outside
+    // -180 to 180 are converted to lie within the range [-180,180]
+    float lat = std::stof(parts[0]);
+    if (lat < -90.0f || lat > 90.0f) {
+      throw std::runtime_error("Latitude must be in the range [-90, 90] degrees");
+    }
+    float lng = std::stof(parts[1]);
+    if (lng < -360.0f || lng > 360.0f) {
+      throw std::runtime_error("Longitude must be in the range [-360, 360] degrees");
+    }
+    if (lng < -180.0f) {
+      lng += 360.0f;
+    } else if (lng > 180.0f) {
+      lng -= 360.0f;
+    }
+
     //make the lng, lat and check for info about the stop type
-    Location l({std::stof(parts[1]), std::stof(parts[0])},
+    Location l({lng, lat},
       (parts.size() > 2 && parts[2] == "through" ? StopType::THROUGH : StopType::BREAK));
 
     //grab some address info

--- a/valhalla/baldr/directededge.h
+++ b/valhalla/baldr/directededge.h
@@ -16,7 +16,7 @@ constexpr uint8_t kMcn = 8;   // Part of mountain bicycle network
 constexpr uint8_t kMaxBicycleNetwork = 15;
 
 // Maximum offset to edge information
-constexpr uint32_t kMaxEdgeInfoOffset = 16777215;   // 2^24 bytes
+constexpr uint32_t kMaxEdgeInfoOffset = 33554431;   // 2^25 bytes
 
 // Maximum length of an edge
 constexpr uint32_t kMaxEdgeLength = 16777215;   // 2^24 meters
@@ -354,7 +354,7 @@ class DirectedEdge {
   // Data offsets and flags for extended data. Where a flag exists the actual
   // data can be indexed by the directed edge Id within the tile.
   struct DataOffsets {
-    uint32_t edgeinfo_offset   : 24; // Offset to edge data.
+    uint32_t edgeinfo_offset   : 25; // Offset to edge data.
     uint32_t access_conditions :  1; // General restriction or access
                                      // condition
     uint32_t start_ttr         :  1; // Directed edge starts a simple timed
@@ -364,7 +364,7 @@ class DirectedEdge {
     uint32_t end_mer           :  1; // Directed edge ends a multi-edge
                                      // restriction
     uint32_t exitsign          :  1; // Does this directed edge have exit signs
-    uint32_t spare             :  3;
+    uint32_t spare             :  2;
   };
   DataOffsets dataoffsets_;
 


### PR DESCRIPTION
Validate and fix lat,lng inputs - throw exception if lng is outside range from -360 to 360 degrees or lat is outside -90 to 90 degrees. Fix longitude to lie within -180 to 180 degrees.

Increase max edge info offsets. Believe there are a few very dense areas in Asia where we don't drop enough edges going from local to arterial.