### PR TITLE
Needed 4 bits for opposing local index. 

### DIFF
--- a/src/baldr/directededge.cc
+++ b/src/baldr/directededge.cc
@@ -265,7 +265,9 @@ bool DirectedEdge::internal() const {
 // Gets the turn type given the prior edge's local index
 Turn::Type DirectedEdge::turntype(const uint32_t localidx) const {
   // Turn type is 3 bits per index
-  return static_cast<Turn::Type>(turntypes_.turntype & (7 << (localidx * 3)));
+  uint32_t shift = localidx * 3;
+  return static_cast<Turn::Type>(
+      ((turntypes_.turntype & (7 << shift))) >> shift);
 }
 
 // Is there a consistent name between this edge and the
@@ -279,7 +281,8 @@ bool DirectedEdge::consistent_name(const uint32_t localidx) const {
 // by the local index of the corresponding inbound edge at the node).
 uint32_t DirectedEdge::stopimpact(const uint32_t localidx) const {
   // Stop impact is 3 bits per index
-  return (stopimpact_.stopimpact & (7 << (localidx * 3)));
+  uint32_t shift = localidx * 3;
+  return (stopimpact_.stopimpact & (7 << shift)) >> shift;
 }
 
 // Get the internal version. Used for data validity checks.

--- a/valhalla/baldr/directededge.h
+++ b/valhalla/baldr/directededge.h
@@ -30,6 +30,12 @@ constexpr float kMaxSpeed = 255.0f;
 // Maximum lane count
 constexpr uint32_t kMaxLaneCount = 15;
 
+// Number of edges considered for edge transitions
+constexpr uint32_t kNumberOfEdgeTransitions = 8;
+
+// Maximum opposing local edge index
+constexpr uint32_t kMaxOppLocalIdx = 15;
+
 // Maximum stop impact
 constexpr uint32_t kMaxStopImpact = 7;
 
@@ -441,8 +447,8 @@ class DirectedEdge {
                                   // at the end node that are restricted.
     uint64_t use            : 6;  // Specific use types
     uint64_t speed_type     : 2;  // Speed type (tagged vs. categorized)
-    uint64_t opp_local_idx  : 3;  // Opposing local edge index (for costing)
-    uint64_t spare          : 4;
+    uint64_t opp_local_idx  : 4;  // Opposing local edge index (for costing)
+    uint64_t spare          : 3;
   };
   Attributes attributes_;
 
@@ -480,6 +486,7 @@ class DirectedEdge {
   };
   StopImpact stopimpact_;
 
+  // TODO - can use this for extra edge transition logic if needed
   uint32_t spare;
 
   // TODO - fields for describing intersection transitions


### PR DESCRIPTION
Any value > max transitions 8 will not be able to look up edge transition information, but we need a value > 8
so a valid value is not used in cases where > 8 edges occur at a node.