### PR TITLE
let people access, constly, the hierarchy information so we dont have to...

### DIFF
--- a/src/baldr/graphid.cc
+++ b/src/baldr/graphid.cc
@@ -81,6 +81,10 @@ bool GraphId::operator !=(const GraphId& rhs) const {
   return value != rhs.value;
 }
 
+GraphId::operator uint64_t() const {
+  return value;
+}
+
 std::ostream& operator<<(std::ostream& os, const GraphId& id)
 {
     return os << id.fields.level << '/' << id.fields.tileid << '/' << id.fields.id;

--- a/src/baldr/graphreader.cc
+++ b/src/baldr/graphreader.cc
@@ -16,13 +16,6 @@ GraphReader::GraphReader(const boost::property_tree::ptree& pt):GraphReader(Tile
 GraphReader::GraphReader(const TileHierarchy& th):tile_hierarchy_(th) {
 }
 
-// Method to test if tile exists
-bool GraphReader::DoesTileExist(const GraphId& graphid) const {
-//  return boost::filesystem::exists(boost::filesystem::path(
-//      GraphTile::Filename(tile_hierarchy_.tile_dir(), graphid)));
-  return true;  // TODO! do we need this?
-}
-
 // Get a pointer to a graph tile object given a GraphId.
 const GraphTile* GraphReader::GetGraphTile(const GraphId& graphid) {
   // Check if the level/tileid combination is in the cache
@@ -47,6 +40,11 @@ const GraphTile* GraphReader::GetGraphTile(const PointLL& pointll, const uint8_t
 const GraphTile* GraphReader::GetGraphTile(const PointLL& pointll){
   return GetGraphTile(pointll, tile_hierarchy_.levels().rbegin()->second.level);
 }
+
+const TileHierarchy& GraphReader::GetTileHierarchy() const {
+  return tile_hierarchy_;
+}
+
 
 }
 }

--- a/src/baldr/graphreader.cc
+++ b/src/baldr/graphreader.cc
@@ -3,7 +3,7 @@
 #include <string>
 #include <iostream>
 #include <fstream>
-//#include <boost/filesystem/operations.hpp>
+#include <sys/stat.h>
 
 namespace valhalla {
 namespace baldr {
@@ -14,6 +14,17 @@ GraphReader::GraphReader(const boost::property_tree::ptree& pt):GraphReader(Tile
 }
 
 GraphReader::GraphReader(const TileHierarchy& th):tile_hierarchy_(th) {
+}
+
+// Method to test if tile exists
+bool GraphReader::DoesTileExist(const GraphId& graphid) const {
+  return DoesTileExist(tile_hierarchy_, graphid);
+}
+bool GraphReader::DoesTileExist(const TileHierarchy& tile_hierarchy, const GraphId& graphid) {
+  std::string file_location = tile_hierarchy.tile_dir() + "/" +
+    GraphTile::FileSuffix(graphid.Tile_Base(), tile_hierarchy);
+  struct stat buffer;
+  return stat(file_location.c_str(), &buffer) == 0;
 }
 
 // Get a pointer to a graph tile object given a GraphId.

--- a/valhalla/baldr/graphid.h
+++ b/valhalla/baldr/graphid.h
@@ -97,6 +97,9 @@ union GraphId {
 
   bool operator !=(const GraphId& rhs) const;
 
+  // cast operator
+  operator uint64_t() const;
+
   struct Fields {
     //the tile id
     uint64_t tileid :24;

--- a/valhalla/baldr/graphreader.h
+++ b/valhalla/baldr/graphreader.h
@@ -32,12 +32,6 @@ class GraphReader {
   GraphReader(const TileHierarchy& th);
 
   /**
-   * Test if tile exists
-   * @param  graphid  GraphId of the tile to test (tile id and level).
-   */
-  bool DoesTileExist(const GraphId& graphid) const;
-
-  /**
    * Get a pointer to a graph tile object given a GraphId.
    * @param graphid  the graphid of the tile
    * @return GraphTile* a pointer to the graph tile
@@ -59,10 +53,15 @@ class GraphReader {
    */
   const GraphTile* GetGraphTile(const PointLL& pointll);
 
+  /**
+   * Get the tile hierarchy used in this graph reader
+   * @return hierarchy
+   */
+  const TileHierarchy& GetTileHierarchy() const;
+
  protected:
   // Information about where the tiles are kept
-  // TODO: make this const
-  TileHierarchy tile_hierarchy_;
+  const TileHierarchy tile_hierarchy_;
 
   // The actual cached GraphTile objects
   std::unordered_map<GraphId, GraphTile> tilecache_;

--- a/valhalla/baldr/graphreader.h
+++ b/valhalla/baldr/graphreader.h
@@ -32,6 +32,13 @@ class GraphReader {
   GraphReader(const TileHierarchy& th);
 
   /**
+   * Test if tile exists
+   * @param  graphid  GraphId of the tile to test (tile id and level).
+   */
+  bool DoesTileExist(const GraphId& graphid) const;
+  static bool DoesTileExist(const TileHierarchy& tile_hierarchy, const GraphId& graphid);
+
+  /**
    * Get a pointer to a graph tile object given a GraphId.
    * @param graphid  the graphid of the tile
    * @return GraphTile* a pointer to the graph tile


### PR DESCRIPTION
... carry two objects around all the time. this seemed more conveniant than having to pass around two objects (in all of the builder stuff for example)