### PR TITLE
Updates for edge transitions

### DIFF
--- a/test/directededge.cc
+++ b/test/directededge.cc
@@ -5,9 +5,9 @@
 using namespace std;
 using namespace valhalla::baldr;
 
-// Expected size is 48 bytes. Since there are still "spare" bits
+// Expected size is 40 bytes. Since there are still "spare" bits
 // we want to alert if somehow any change grows this structure size
-constexpr size_t kDirectedEdgeExpectedSize = 48;
+constexpr size_t kDirectedEdgeExpectedSize = 40;
 
 namespace {
 

--- a/test/nodeinfo.cc
+++ b/test/nodeinfo.cc
@@ -7,9 +7,9 @@ using namespace std;
 using namespace valhalla::baldr;
 using namespace valhalla::midgard;
 
-// Expected size is 24 bytes. Since there are still "spare" bits
+// Expected size is 32 bytes. Since there are still "spare" bits
 // we want to alert if somehow any change grows this structure size
-constexpr size_t kNodeInfoExpectedSize = 24;
+constexpr size_t kNodeInfoExpectedSize = 32;
 
 namespace {
 

--- a/valhalla/baldr/directededge.h
+++ b/valhalla/baldr/directededge.h
@@ -362,12 +362,11 @@ class DirectedEdge {
   Turn::Type turntype(const uint32_t localidx) const;
 
   /**
-   * Is there a consistent name between this edge and the
-   * prior edge given its local index (index of the inbound edge).
-   * @param  localidx  Local index at the node of the inbound edge.
-   * @return  Returns true if there is a consistent name, false if not.
+   * Is there an edge to the left, in between the from edge and this edge.
+   * @param localidx  Local index at the node of the inbound edge.
+   * @return  Returns true if there is an edge to the left, false if not.
    */
-  bool consistent_name(const uint32_t localidx) const;
+  bool edge_to_left(const uint32_t localidx) const;
 
   /**
    * Get the stop impact when transitioning from the prior edge (given
@@ -377,7 +376,12 @@ class DirectedEdge {
    */
   uint32_t stopimpact(const uint32_t localidx) const;
 
-  // TODO - intersection transitions
+  /**
+   * Is there an edge to the right, in between the from edge and this edge.
+   * @param localidx  Local index at the node of the inbound edge.
+   * @return  Returns true if there is an edge to the right, false if not.
+   */
+  bool edge_to_right(const uint32_t localidx) const;
 
   /**
    * Get the computed version of DirectedEdge attributes.
@@ -471,26 +475,22 @@ class DirectedEdge {
 
   // Turn types between edges
   struct TurnTypes {
-    uint32_t turntype        : 24; // Turn type
-    uint32_t consistent_name :  8; // Name consistency between edges
+    uint32_t turntype      : 24; // Turn type (see graphconstants.h)
+    uint32_t edge_to_left  :  8; // Is there an edge to the left (between the
+                                 // "from edge" and this edge)
   };
   TurnTypes turntypes_;
 
   // Stop impact among edges
   struct StopImpact {
     uint32_t stopimpact      : 24; // Stop impact between edges
-    uint32_t spare           :  8;
+    uint32_t edge_to_right   :  8; // Is there an edge to the right (between
+                                   // "from edge" and this edge)
   };
   StopImpact stopimpact_;
 
-  // TODO - can use this for extra edge transition logic if needed
+  // Spare
   uint32_t spare;
-
-  // TODO - fields for describing intersection transitions
-  struct IntersectionTransition {
-    uint64_t spare           : 64;
-  };
-  IntersectionTransition transitions_;
 };
 
 }

--- a/valhalla/baldr/graphconstants.h
+++ b/valhalla/baldr/graphconstants.h
@@ -38,6 +38,14 @@ union Access {
   uint8_t v;
 };
 
+// Edge driveability (auto)
+enum class Driveability {
+  kNone = 0,        // Edge is not driveable in either direction
+  kForward = 1,     // Edge is driveable in the forward direction
+  kBackward = 2,    // Edge is driveable in the backward direction
+  kBoth = 3         // Edge is driveable in both directions
+};
+
 // Road class or importance of an edge
 enum class RoadClass : uint8_t {
   kMotorway = 0,


### PR DESCRIPTION
NodeInfo size increased to 32bytes: added name continuity, headings, and driveability for up to 8 edges (using local edge index to reference).
DirectedEdge size reduce to 40 bytes: added edge_to_left and edge_to_right flags but removed name continuity and spare 64bit word reserved for edge transitions (not needed due to additions to NodeInfo).
