### PR TITLE
Add is_shortcut flag. 

### DIFF
--- a/src/baldr/directededge.cc
+++ b/src/baldr/directededge.cc
@@ -290,6 +290,11 @@ bool DirectedEdge::trans_down() const {
   return hierarchy_.trans_down;
 }
 
+// Is this directed edge a shortcut?
+bool DirectedEdge::is_shortcut() const {
+  return hierarchy_.is_shortcut;
+}
+
 // Get the internal version. Used for data validity checks.
 const uint64_t DirectedEdge::internal_version() {
   uint64_t seed = 0;
@@ -427,6 +432,8 @@ const uint64_t DirectedEdge::internal_version() {
   boost::hash_combine(seed,ffs(de.hierarchy_.shortcut+1)-1);
   de.hierarchy_.superseded = ~de.hierarchy_.superseded;
   boost::hash_combine(seed,ffs(de.hierarchy_.superseded+1)-1);
+  de.hierarchy_.is_shortcut = ~de.hierarchy_.is_shortcut;
+  boost::hash_combine(seed,ffs(de.hierarchy_.is_shortcut+1)-1);
   de.hierarchy_.spare = ~de.hierarchy_.spare;
   boost::hash_combine(seed,ffs(de.hierarchy_.spare+1)-1);
 

--- a/valhalla/baldr/directededge.h
+++ b/valhalla/baldr/directededge.h
@@ -33,7 +33,8 @@ constexpr uint32_t kMaxLaneCount = 15;
 // Number of edges considered for edge transitions
 constexpr uint32_t kNumberOfEdgeTransitions = 8;
 
-// Maximum shortcuts edges from a node
+// Maximum shortcuts edges from a node. More than this can be
+// added but this is the max. that can supersede an edge
 constexpr uint32_t kMaxShortcutsFromNode = 7;
 
 // Maximum stop impact
@@ -389,6 +390,13 @@ class DirectedEdge {
   bool trans_down() const;
 
   /**
+   * Is this edge a shortcut edge. If there are more than kMaxShortcutsFromNode
+   * shortcuts no mask is set but this flag is set to true.
+   * @return  Returns true if this edge is a shortcut.
+   */
+  bool is_shortcut() const;
+
+  /**
    * Get the computed version of DirectedEdge attributes.
    * @return   Returns internal version.
    */
@@ -498,7 +506,8 @@ class DirectedEdge {
     uint32_t trans_up       : 1;  // Edge represents a transition up one
                                   // level in the hierarchy
     uint32_t trans_down     : 1;  // Transition down one level
-    uint32_t spare          : 2;
+    uint32_t is_shortcut    : 1;  // True if this edge is a shortcut.
+    uint32_t spare          : 1;
   };
   Hierarchy hierarchy_;
 };


### PR DESCRIPTION
Only kMaxShortcutsFromNode can have a mask and supersede an edge, but more than this # of shortcuts can be stored.