### PR TITLE
default to break for location type

### DIFF
--- a/src/baldr/location.cc
+++ b/src/baldr/location.cc
@@ -19,8 +19,8 @@ Location Location::FromPtree(const boost::property_tree::ptree& pt) {
 
   Location location(
       { pt.get<float>("longitude"), pt.get<float>("latitude") },
-      (pt.get<std::string>("type") == "through" ?
-          StopType::THROUGH : StopType::BREAK));
+      (pt.get<std::string>("type", "break") == "break" ?
+        StopType::BREAK : StopType::THROUGH));
   //LOG_INFO("LAT=" + std::to_string(location.latlng_.lat()));
   //LOG_INFO("LNG=" + std::to_string(location.latlng_.lng()));
   //LOG_INFO("TYPE=" + pt.get<std::string>("type"));


### PR DESCRIPTION
updated tests, removed explicit testing of `FromPtree` since the test was just doing exactly what `FromJson` does, ie. make a ptree and then just call `FromPtree`