### PR TITLE
Update comments for admin methods. 

### DIFF
--- a/src/baldr/graphtile.cc
+++ b/src/baldr/graphtile.cc
@@ -252,10 +252,9 @@ std::vector<std::string> GraphTile::GetNames(const uint32_t edgeinfo_offset) con
 }
 
 // Get the admininfo at the specified index.
-const AdminInfo GraphTile::admininfo(const size_t idx) const {
+AdminInfo GraphTile::admininfo(const size_t idx) const {
   if (idx < header_->admincount()) {
     const Admin& admin = admins_[idx];
-
     return AdminInfo(textlist_ + admin.country_offset(),
                      textlist_ + admin.state_offset(),
                      admin.country_iso(), admin.state_iso(),
@@ -265,9 +264,9 @@ const AdminInfo GraphTile::admininfo(const size_t idx) const {
 }
 
 // Get the admin at the specified index.
-const Admin GraphTile::admin(const size_t idx) const {
+const Admin* GraphTile::admin(const size_t idx) const {
   if (idx < header_->admincount()) {
-    return admins_[idx];
+    return &admins_[idx];
   }
   throw std::runtime_error("GraphTile Admin index out of bounds");
 }

--- a/valhalla/baldr/graphtile.h
+++ b/valhalla/baldr/graphtile.h
@@ -124,11 +124,20 @@ class GraphTile {
    */
   std::vector<std::string> GetNames(const uint32_t edgeinfo_offset) const;
 
-  // Get the admininfo at the specified index.
-  const AdminInfo admininfo(const size_t idx) const;
+  /**
+   * Get the admininfo at the specified index. Populates the state name and
+   * country name from the text/name list.
+   * @param  idx  Index into the admin list.
+   * @return  Returns the admin information.
+   */
+  AdminInfo admininfo(const size_t idx) const;
 
-  // Get the admin at the specified index.
-  const Admin admin(const size_t idx) const;
+  /**
+   * Get the admin at the specified index.
+   * @param  idx  Index into the admin list.
+   * @return  Returns a pointer to the admin structure.
+   */
+  const Admin* admin(const size_t idx) const;
 
   /**
    * Convenience method to get the signs for an edge given the directed


### PR DESCRIPTION
Return a const pointer to avoid a copy to the base structure.