### PR TITLE
Add methods to get a map of populated tiles and a connectivity map.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -98,14 +98,14 @@ libvalhalla_baldr_la_SOURCES = \
 	src/baldr/transittransfer.cc \
 	src/baldr/transittrip.cc 
 libvalhalla_baldr_la_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_CPPFLAGS) @BOOST_CPPFLAGS@
-libvalhalla_baldr_la_LIBADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) @BOOST_LDFLAGS@ $(BOOST_SYSTEM_LIB) $(BOOST_THREAD_LIB)
+libvalhalla_baldr_la_LIBADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) @BOOST_LDFLAGS@ $(BOOST_SYSTEM_LIB) $(BOOST_FILESYSTEM_LIB) $(BOOST_THREAD_LIB)
 
 #distributed executables
 bin_PROGRAMS = srtmtest
 srtmtest_SOURCES = \
         src/baldr/srtmtest/srtmtest.cc
 srtmtest_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_CPPFLAGS) @BOOST_CPPFLAGS@
-srtmtest_LDADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) @BOOST_LDFLAGS@ -lz libvalhalla_baldr.la
+srtmtest_LDADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) @BOOST_LDFLAGS@  $(BOOST_FILESYSTEM_LIB) -lz libvalhalla_baldr.la
 
 # tests
 check_PROGRAMS = \

--- a/configure.ac
+++ b/configure.ac
@@ -28,6 +28,7 @@ CHECK_VALHALLA_MIDGARD
 AX_BOOST_BASE([1.54], , [AC_MSG_ERROR([cannot find Boost libraries, which are are required for building valhalla. Please install libboost-dev.])])
 AX_BOOST_SYSTEM
 AX_BOOST_THREAD
+AX_BOOST_FILESYSTEM
 
 # optionally enable coverage information
 CHECK_COVERAGE

--- a/m4/ax_boost_filesystem.m4
+++ b/m4/ax_boost_filesystem.m4
@@ -1,0 +1,119 @@
+# ===========================================================================
+#    http://www.gnu.org/software/autoconf-archive/ax_boost_filesystem.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_BOOST_FILESYSTEM
+#
+# DESCRIPTION
+#
+#   Test for Filesystem library from the Boost C++ libraries. The macro
+#   requires a preceding call to AX_BOOST_BASE. Further documentation is
+#   available at <http://randspringer.de/boost/index.html>.
+#
+#   This macro calls:
+#
+#     AC_SUBST(BOOST_FILESYSTEM_LIB)
+#
+#   And sets:
+#
+#     HAVE_BOOST_FILESYSTEM
+#
+# LICENSE
+#
+#   Copyright (c) 2009 Thomas Porschberg <thomas@randspringer.de>
+#   Copyright (c) 2009 Michael Tindal
+#   Copyright (c) 2009 Roman Rybalko <libtorrent@romanr.info>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 26
+
+AC_DEFUN([AX_BOOST_FILESYSTEM],
+[
+	AC_ARG_WITH([boost-filesystem],
+	AS_HELP_STRING([--with-boost-filesystem@<:@=special-lib@:>@],
+                   [use the Filesystem library from boost - it is possible to specify a certain library for the linker
+                        e.g. --with-boost-filesystem=boost_filesystem-gcc-mt ]),
+        [
+        if test "$withval" = "no"; then
+			want_boost="no"
+        elif test "$withval" = "yes"; then
+            want_boost="yes"
+            ax_boost_user_filesystem_lib=""
+        else
+		    want_boost="yes"
+		ax_boost_user_filesystem_lib="$withval"
+		fi
+        ],
+        [want_boost="yes"]
+	)
+
+	if test "x$want_boost" = "xyes"; then
+        AC_REQUIRE([AC_PROG_CC])
+		CPPFLAGS_SAVED="$CPPFLAGS"
+		CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
+		export CPPFLAGS
+
+		LDFLAGS_SAVED="$LDFLAGS"
+		LDFLAGS="$LDFLAGS $BOOST_LDFLAGS"
+		export LDFLAGS
+
+		LIBS_SAVED=$LIBS
+		LIBS="$LIBS $BOOST_SYSTEM_LIB"
+		export LIBS
+
+        AC_CACHE_CHECK(whether the Boost::Filesystem library is available,
+					   ax_cv_boost_filesystem,
+        [AC_LANG_PUSH([C++])
+         AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[@%:@include <boost/filesystem/path.hpp>]],
+                                   [[using namespace boost::filesystem;
+                                   path my_path( "foo/bar/data.txt" );
+                                   return 0;]])],
+					       ax_cv_boost_filesystem=yes, ax_cv_boost_filesystem=no)
+         AC_LANG_POP([C++])
+		])
+		if test "x$ax_cv_boost_filesystem" = "xyes"; then
+			AC_DEFINE(HAVE_BOOST_FILESYSTEM,,[define if the Boost::Filesystem library is available])
+            BOOSTLIBDIR=`echo $BOOST_LDFLAGS | sed -e 's/@<:@^\/@:>@*//'`
+            if test "x$ax_boost_user_filesystem_lib" = "x"; then
+                for libextension in `ls -r $BOOSTLIBDIR/libboost_filesystem* 2>/dev/null | sed 's,.*/lib,,' | sed 's,\..*,,'` ; do
+                     ax_lib=${libextension}
+				    AC_CHECK_LIB($ax_lib, exit,
+                                 [BOOST_FILESYSTEM_LIB="-l$ax_lib"; AC_SUBST(BOOST_FILESYSTEM_LIB) link_filesystem="yes"; break],
+                                 [link_filesystem="no"])
+				done
+                if test "x$link_filesystem" != "xyes"; then
+                for libextension in `ls -r $BOOSTLIBDIR/boost_filesystem* 2>/dev/null | sed 's,.*/,,' | sed -e 's,\..*,,'` ; do
+                     ax_lib=${libextension}
+				    AC_CHECK_LIB($ax_lib, exit,
+                                 [BOOST_FILESYSTEM_LIB="-l$ax_lib"; AC_SUBST(BOOST_FILESYSTEM_LIB) link_filesystem="yes"; break],
+                                 [link_filesystem="no"])
+				done
+		    fi
+            else
+               for ax_lib in $ax_boost_user_filesystem_lib boost_filesystem-$ax_boost_user_filesystem_lib; do
+				      AC_CHECK_LIB($ax_lib, exit,
+                                   [BOOST_FILESYSTEM_LIB="-l$ax_lib"; AC_SUBST(BOOST_FILESYSTEM_LIB) link_filesystem="yes"; break],
+                                   [link_filesystem="no"])
+                  done
+
+            fi
+            if test "x$ax_lib" = "x"; then
+                AC_MSG_ERROR(Could not find a version of the library!)
+            fi
+			if test "x$link_filesystem" != "xyes"; then
+				AC_MSG_ERROR(Could not link against $ax_lib !)
+			fi
+		fi
+
+		CPPFLAGS="$CPPFLAGS_SAVED"
+		LDFLAGS="$LDFLAGS_SAVED"
+		LIBS="$LIBS_SAVED"
+	fi
+])
+

--- a/scripts/dependencies.sh
+++ b/scripts/dependencies.sh
@@ -2,7 +2,7 @@
 set -e
 
 export LD_LIBRARY_PATH=.:`cat /etc/ld.so.conf.d/* | grep -v -E "#" | tr "\\n" ":" | sed -e "s/:$//g"`
-sudo apt-get install -y autoconf automake libtool make gcc-4.8 g++-4.8 libboost1.54-dev libboost-system1.54-dev libboost-thread1.54-dev lcov
+sudo apt-get install -y autoconf automake libtool make gcc-4.8 g++-4.8 libboost1.54-dev libboost-system1.54-dev libboost-filesystem1.54-dev libboost-thread1.54-dev lcov
 sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
 
 #clone async

--- a/src/baldr/graphtile.cc
+++ b/src/baldr/graphtile.cc
@@ -12,6 +12,7 @@
 #include <locale>
 #include <iomanip>
 #include <cmath>
+#include <boost/algorithm/string.hpp>
 
 namespace {
   struct dir_facet : public std::numpunct<char> {
@@ -199,6 +200,31 @@ std::string GraphTile::FileSuffix(const GraphId& graphid, const TileHierarchy& h
   //it was something else
   stream << graphid.level() * static_cast<uint32_t>(std::pow(10, max_length)) + graphid.tileid() << ".gph";
   return stream.str();
+}
+
+// Get the tile Id given the full path to the file.
+GraphId GraphTile::GetTileId(const std::string& fname) {
+  // Tokenize the string
+  std::vector<std::string> tokens;
+  boost::split(tokens, fname, boost::is_any_of("/"));
+  size_t n = tokens.size();
+
+  // Strip off the .gph from the last token
+  std::string idn;
+  for (size_t i = 0; i < tokens[n-1].size(); i++) {
+    char c = tokens[n-1].at(i);
+    if (c == '.') {
+      break;
+    }
+    idn += c;
+  }
+
+  // Compute the Id
+  uint32_t id = std::atoi(tokens[n-3].c_str()) * 1000000 +
+                std::atoi(tokens[n-2].c_str()) * 1000 +
+                std::atoi(idn.c_str());
+  uint32_t level = std::atoi(tokens[n-4].c_str());
+  return {id, level, 0};
 }
 
 size_t GraphTile::size() const {

--- a/valhalla/baldr/graphreader.h
+++ b/valhalla/baldr/graphreader.h
@@ -32,6 +32,24 @@ class GraphReader {
   static bool DoesTileExist(const TileHierarchy& tile_hierarchy, const GraphId& graphid);
 
   /**
+   * Get a tile "map" - bool vector identifying which tiles exist.
+   * @param  level  Tile hierarchy level used to get the tile map.
+   * @return  Returns the tile map - vector of bool indicating which tiles
+   *          exist.
+   */
+  std::vector<bool> TileMap(const uint32_t level);
+
+  /**
+   * Get a tile connectivity map. This is a vector where each tile Id is
+   * assigned an integer value. Connected tiles will have the same value
+   * while disconnected (no path using poulated tiles exists) will have
+   * different values.
+   * @param  level  Tile hierarchy level used to get the tile map.
+   * @return  Returns the tile connectivity map.
+   */
+  std::vector<uint32_t> ConnectivityMap(const uint32_t level);
+
+  /**
    * Get a pointer to a graph tile object given a GraphId.
    * @param graphid  the graphid of the tile
    * @return GraphTile* a pointer to the graph tile

--- a/valhalla/baldr/graphtile.h
+++ b/valhalla/baldr/graphtile.h
@@ -54,6 +54,13 @@ class GraphTile {
   static std::string FileSuffix(const GraphId& graphid, const TileHierarchy& hierarchy);
 
   /**
+   * Get the tile Id given the full path to the file.
+   * @param  fname  Filename with complete path.
+   * @return  Returns the tile Id.
+   */
+  static GraphId GetTileId(const std::string& fname);
+
+  /**
    * Gets the size of the tile in bytes. A value of 0 indicates an empty tile. A value
    * of 0 indicates an error reading the tile data.
    * or unsuccessful read.


### PR DESCRIPTION
This will allow testing origin and destination to see if a path of populated tiles connects them. We can very quickly reject paths between locations that have no possible connectivity. To handle long ferries we can add "empty" tiles for where the ferry crosses but no end nodes exist.

Also added a method to return the tile Id given the filename (no need to actually open/read the file).