### PR TITLE
update connectivity map to be singleton

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -40,6 +40,7 @@ lib_LTLIBRARIES = libvalhalla_baldr.la
 nobase_include_HEADERS = \
 	valhalla/baldr/admin.h \
         valhalla/baldr/admininfo.h \
+	valhalla/baldr/connectivity_map.h \
 	valhalla/baldr/datetime.h \
 	valhalla/baldr/directededge.h \
 	valhalla/baldr/edgeinfo.h \
@@ -71,6 +72,7 @@ nobase_include_HEADERS = \
 libvalhalla_baldr_la_SOURCES = \
         src/baldr/admin.cc \
 	src/baldr/admininfo.cc \
+	src/baldr/connectivity_map.cc \
 	src/baldr/datetime.cc \
 	src/baldr/directededge.cc \
 	src/baldr/edgeinfo.cc \

--- a/src/baldr/connectivity_map.cc
+++ b/src/baldr/connectivity_map.cc
@@ -1,0 +1,160 @@
+#include "baldr/connectivity_map.h"
+#include "baldr/json.h"
+#include "baldr/graphtile.h"
+
+#include <valhalla/midgard/pointll.h>
+#include <boost/filesystem.hpp>
+#include <list>
+
+using namespace valhalla::baldr;
+using namespace valhalla::midgard;
+
+namespace {
+/*
+   { "type": "FeatureCollection",
+    "features": [
+      { "type": "Feature",
+        "geometry": {"type": "Point", "coordinates": [102.0, 0.5]},
+        "properties": {"prop0": "value0"}
+        },
+      { "type": "Feature",
+        "geometry": {
+          "type": "LineString",
+          "coordinates": [
+            [102.0, 0.0], [103.0, 1.0], [104.0, 0.0], [105.0, 1.0]
+            ]
+          },
+        "properties": {
+          "prop0": "value0",
+          "prop1": 0.0
+          }
+        },
+      { "type": "Feature",
+         "geometry": {
+           "type": "Polygon",
+           "coordinates": [
+             [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0],
+               [100.0, 1.0], [100.0, 0.0] ]
+             ]
+         },
+         "properties": {
+           "prop0": "value0",
+           "prop1": {"this": "that"}
+           }
+         }
+       ]
+     }
+   */
+
+  json::MapPtr to_properties(const size_t color) {
+    return json::map({
+      {std::string("color"), static_cast<uint64_t>(color)}
+    });
+  }
+
+  json::MapPtr to_geometry(const std::list<PointLL>& tiles) {
+    auto multipoint = json::array({});
+    for(const auto& tile : tiles)
+      multipoint->emplace_back(json::array({json::fp_t{tile.first, 6}, json::fp_t{tile.second, 6}}));
+    return json::map({
+      {std::string("type"), std::string("MultiPoint")},
+      {std::string("coordinates"), multipoint}
+    });
+  }
+
+  json::MapPtr to_feature(const std::pair<size_t, std::list<PointLL> >& region) {
+    return json::map({
+      {std::string("type"), std::string("Feature")},
+      {std::string("geometry"), to_geometry(region.second)},
+      {std::string("properties"), to_properties(region.first)}
+    });
+  }
+
+  std::string to_feature_collection(const std::unordered_map<size_t, std::list<PointLL> >& regions) {
+    auto features = json::array({});
+    for(const auto& region : regions)
+      features->emplace_back(to_feature(region));
+    std::stringstream ss;
+    ss << *json::map({
+      {std::string("type"), std::string("FeatureCollection")},
+      {std::string("features"), features}
+    });
+    return ss.str();
+  }
+}
+
+namespace valhalla {
+  namespace baldr {
+    connectivity_map_t::connectivity_map_t(const TileHierarchy& tile_hierarchy):tile_hierarchy(tile_hierarchy) {
+      // Populate a map for each level of the tiles that exist
+      for (const auto& tile_level : tile_hierarchy.levels()) {
+        try {
+          auto& level_colors = colors.insert({tile_level.first, std::unordered_map<uint32_t, size_t>{}}).first->second;
+          boost::filesystem::path root_dir(tile_hierarchy.tile_dir() + '/' + std::to_string(tile_level.first) + '/');
+          if(boost::filesystem::exists(root_dir) && boost::filesystem::is_directory(root_dir)) {
+            for (boost::filesystem::recursive_directory_iterator i(root_dir), end; i != end; ++i) {
+              if (!boost::filesystem::is_directory(i->path())) {
+                GraphId id = GraphTile::GetTileId(i->path().string(), tile_hierarchy);
+                level_colors.insert({id.tileid(), 0});
+              }
+            }
+          }
+        }
+        catch(...) {
+        }
+      }
+
+      // All tiles have color 0 (not connected), go through each level and connect them
+      for(auto& level_colors : colors) {
+        auto level = tile_hierarchy.levels().find(level_colors.first);
+        level->second.tiles.ColorMap(level_colors.second);
+      }
+    }
+    size_t connectivity_map_t::get_color(const GraphId& id) const {
+      auto level = colors.find(id.level());
+      if(level == colors.cend())
+        return 0;
+      auto color = level->second.find(id.tileid());
+      if(color == level->second.cend())
+        return 0;
+      return color->second;
+    }
+    std::string connectivity_map_t::to_geojson(const uint32_t hierarchy_level) const {
+      //bail if we dont have the level
+      auto bbox = tile_hierarchy.levels().find(hierarchy_level);
+      auto level = colors.find(hierarchy_level);
+      if(bbox == tile_hierarchy.levels().cend() || level == colors.cend())
+        throw std::runtime_error("hierarchy level not found");
+
+      //make a region map (inverse mapping of color to lists of tiles)
+      //could cache this but shouldnt need to call it much
+      std::unordered_map<size_t, std::list<PointLL> > regions;
+      for(const auto& tile : level->second) {
+        auto region = regions.find(tile.second);
+        if(region == regions.end())
+          regions.insert({tile.second, {bbox->second.tiles.Center(tile.first)}});
+        else
+          region->second.push_back(bbox->second.tiles.Center(tile.first));
+      }
+      //turn it into geojson
+      return to_feature_collection(regions);
+    }
+
+    std::vector<size_t> connectivity_map_t::to_image(const uint32_t hierarchy_level) const {
+      //bail if we dont have the level
+      auto bbox = tile_hierarchy.levels().find(hierarchy_level);
+      auto level = colors.find(hierarchy_level);
+      if(bbox == tile_hierarchy.levels().cend() || level == colors.cend())
+        throw std::runtime_error("hierarchy level not found");
+
+      std::vector<size_t> tiles(bbox->second.tiles.nrows() * bbox->second.tiles.ncolumns(), static_cast<uint32_t>(0));
+      for(size_t i = 0; i < tiles.size(); ++i) {
+        const auto color = level->second.find(static_cast<uint32_t>(i));
+        if(color != level->second.cend())
+          tiles[i] = color->second;
+      }
+
+      return tiles;
+    }
+  }
+}

--- a/src/baldr/graphreader.cc
+++ b/src/baldr/graphreader.cc
@@ -17,13 +17,19 @@ namespace {
     connectivity_map_t(const TileHierarchy& tile_hierarchy) {
       // Populate a map for each level of the tiles that exist
       for (const auto& tile_level : tile_hierarchy.levels()) {
-        auto level_colors = colors.insert({tile_level.first, std::unordered_map<uint32_t, size_t>{}}).first->second;
-        std::string root_dir = tile_hierarchy.tile_dir() + "/" + std::to_string(tile_level.first);
-        for (boost::filesystem::recursive_directory_iterator i(root_dir), end; i != end; ++i) {
-          if (!is_directory(i->path())) {
-            GraphId id = GraphTile::GetTileId(i->path().string(), tile_hierarchy);
-            level_colors.insert({id.tileid(), 0});
+        try {
+          auto& level_colors = colors.insert({tile_level.first, std::unordered_map<uint32_t, size_t>{}}).first->second;
+          boost::filesystem::path root_dir(tile_hierarchy.tile_dir() + '/' + std::to_string(tile_level.first) + '/');
+          if(boost::filesystem::exists(root_dir) && boost::filesystem::is_directory(root_dir)) {
+            for (boost::filesystem::recursive_directory_iterator i(root_dir), end; i != end; ++i) {
+              if (!boost::filesystem::is_directory(i->path())) {
+                GraphId id = GraphTile::GetTileId(i->path().string(), tile_hierarchy);
+                level_colors.insert({id.tileid(), 0});
+              }
+            }
           }
+        }
+        catch(...) {
         }
       }
 

--- a/src/baldr/graphtile.cc
+++ b/src/baldr/graphtile.cc
@@ -209,27 +209,27 @@ GraphId GraphTile::GetTileId(const std::string& fname, const TileHierarchy& hier
   if(pos == std::string::npos)
     throw std::runtime_error("File name for tile does not match hierarchy root dir");
   auto name = fname.substr(pos + hierarchy.tile_dir().size());
+  boost::algorithm::trim_if(name, boost::is_any_of("/.gph"));
 
-  // Tokenize the string
+  //split on slash
   std::vector<std::string> tokens;
   boost::split(tokens, name, boost::is_any_of("/"));
 
-  // Strip off the .gph from the last token
-  std::vector<std::string> last;
-  boost::split(last, tokens.back(), boost::is_any_of("."));
-  tokens.back() = last.front();
+  //need at least level and id
+  if(tokens.size() < 2)
+    throw std::runtime_error("Invalid tile path");
 
   // Compute the Id
   uint32_t id = 0;
-  uint32_t multiplier = 1;
+  uint32_t multiplier = std::pow(1000, tokens.size() - 2);
   bool first = true;
   for(const auto& token : tokens) {
     if(first) {
       first = false;
       continue;
     }
-    std::atoi(token.c_str()) * multiplier;
-    multiplier += 1000;
+    id += std::atoi(token.c_str()) * multiplier;
+    multiplier /= 1000;
   }
   uint32_t level = std::atoi(tokens.front().c_str());
   return {id, level, 0};

--- a/src/baldr/graphtile.cc
+++ b/src/baldr/graphtile.cc
@@ -203,27 +203,35 @@ std::string GraphTile::FileSuffix(const GraphId& graphid, const TileHierarchy& h
 }
 
 // Get the tile Id given the full path to the file.
-GraphId GraphTile::GetTileId(const std::string& fname) {
+GraphId GraphTile::GetTileId(const std::string& fname, const TileHierarchy& hierarchy) {
+  //strip off the unuseful part
+  auto pos = fname.find(hierarchy.tile_dir());
+  if(pos == std::string::npos)
+    throw std::runtime_error("File name for tile does not match hierarchy root dir");
+  auto name = fname.substr(pos + hierarchy.tile_dir().size());
+
   // Tokenize the string
   std::vector<std::string> tokens;
-  boost::split(tokens, fname, boost::is_any_of("/"));
-  size_t n = tokens.size();
+  boost::split(tokens, name, boost::is_any_of("/"));
 
   // Strip off the .gph from the last token
-  std::string idn;
-  for (size_t i = 0; i < tokens[n-1].size(); i++) {
-    char c = tokens[n-1].at(i);
-    if (c == '.') {
-      break;
-    }
-    idn += c;
-  }
+  std::vector<std::string> last;
+  boost::split(last, tokens.back(), boost::is_any_of("."));
+  tokens.back() = last.front();
 
   // Compute the Id
-  uint32_t id = std::atoi(tokens[n-3].c_str()) * 1000000 +
-                std::atoi(tokens[n-2].c_str()) * 1000 +
-                std::atoi(idn.c_str());
-  uint32_t level = std::atoi(tokens[n-4].c_str());
+  uint32_t id = 0;
+  uint32_t multiplier = 1;
+  bool first = true;
+  for(const auto& token : tokens) {
+    if(first) {
+      first = false;
+      continue;
+    }
+    std::atoi(token.c_str()) * multiplier;
+    multiplier += 1000;
+  }
+  uint32_t level = std::atoi(tokens.front().c_str());
   return {id, level, 0};
 }
 

--- a/test/graphreader.cc
+++ b/test/graphreader.cc
@@ -56,12 +56,30 @@ void TestCacheLimits() {
     throw std::runtime_error("Cache should be over committed");
 }
 
+void TestConnectivityMap() {
+  std::stringstream json; json << "\
+  {\
+    \"tile_dir\": \"test/tiles\",\
+    \"levels\": [\
+      {\"name\": \"local\", \"level\": 2, \"size\": 0.25},\
+      {\"name\": \"arterial\", \"level\": 1, \"size\": 1, \"importance_cutoff\": \"Trunk\"},\
+      {\"name\": \"highway\", \"level\": 0, \"size\": 4}\
+    ]\
+  }";
+
+  boost::property_tree::ptree pt;
+  boost::property_tree::read_json(json, pt);
+
+}
+
 }
 
 int main() {
   test::suite suite("graphtile");
 
   suite.test(TEST_CASE(TestCacheLimits));
+
+  suite.test(TEST_CASE(TestConnectivityMap));
 
   return suite.tear_down();
 }

--- a/test/graphreader.cc
+++ b/test/graphreader.cc
@@ -2,6 +2,9 @@
 
 #include "baldr/graphreader.h"
 
+#include <fcntl.h>
+#include <boost/filesystem.hpp>
+
 using namespace std;
 using namespace valhalla::baldr;
 
@@ -56,7 +59,17 @@ void TestCacheLimits() {
     throw std::runtime_error("Cache should be over committed");
 }
 
+void touch_tile(const uint32_t tile_id, const TileHierarchy& tile_hierarchy) {
+  auto suffix = GraphTile::FileSuffix({tile_id, 2, 0}, tile_hierarchy);
+  auto fullpath = tile_hierarchy.tile_dir() + '/' + suffix;
+  boost::filesystem::create_directories(boost::filesystem::path(fullpath).parent_path());
+  int fd = open(fullpath.c_str(), O_CREAT | O_WRONLY, 0644);
+  if(fd >= 0)
+    close(fd);
+}
+
 void TestConnectivityMap() {
+  //get the hierarchy to create some tiles
   std::stringstream json; json << "\
   {\
     \"tile_dir\": \"test/tiles\",\
@@ -66,10 +79,61 @@ void TestConnectivityMap() {
       {\"name\": \"highway\", \"level\": 0, \"size\": 4}\
     ]\
   }";
-
   boost::property_tree::ptree pt;
   boost::property_tree::read_json(json, pt);
+  TileHierarchy th(pt);
+  const auto& level = th.levels().find(2)->second;
+  boost::filesystem::remove_all(th.tile_dir());
 
+  //looks like this (XX) means no tile there:
+  /*
+   *     XX d1 XX XX
+   *     XX d0 XX XX
+   *     a2 XX c0 XX
+   *     a0 a1 XX b0
+   *
+   */
+
+  //create some empty files with tile names
+  uint32_t a0 = 0;
+  touch_tile(a0, th);
+
+  uint32_t a1 = level.tiles.RightNeighbor(a0);
+  touch_tile(a1, th);
+
+  uint32_t a2 = level.tiles.TopNeighbor(a0);
+  touch_tile(a2, th);
+
+  uint32_t b0 = level.tiles.RightNeighbor(level.tiles.RightNeighbor(a1));
+  touch_tile(b0, th);
+
+  uint32_t c0 =  level.tiles.TopNeighbor(level.tiles.RightNeighbor(a1));
+  touch_tile(c0, th);
+
+  uint32_t d0 = level.tiles.TopNeighbor(level.tiles.RightNeighbor(a2));
+  touch_tile(d0, th);
+
+  uint32_t d1 = level.tiles.TopNeighbor(d0);
+  touch_tile(d1, th);
+
+  //check that it looks right
+  GraphReader reader(pt);
+  if(!reader.AreConnected({a0, 2, 0}, {a1, 2, 0}))
+    throw std::runtime_error("a's should be connected");
+  if(!reader.AreConnected({a0, 2, 0}, {a2, 2, 0}))
+    throw std::runtime_error("a's should be connected");
+  if(!reader.AreConnected({a1, 2, 0}, {a2, 2, 0}))
+    throw std::runtime_error("a's should be connected");
+  if(!reader.AreConnected({d0, 2, 0}, {d1, 2, 0}))
+    throw std::runtime_error("d's should be connected");
+  if(reader.AreConnected({c0, 2, 0}, {a1, 2, 0}))
+    throw std::runtime_error("c is disjoint");
+  if(reader.AreConnected({b0, 2, 0}, {a0, 2, 0}))
+    throw std::runtime_error("b is disjoint");
+  if(reader.AreConnected({a2, 2, 0}, {d0, 2, 0}))
+    throw std::runtime_error("a is disjoint from d");
+
+  boost::filesystem::remove_all(th.tile_dir());
 }
 
 }

--- a/valhalla/baldr/connectivity_map.h
+++ b/valhalla/baldr/connectivity_map.h
@@ -1,0 +1,52 @@
+#ifndef VALHALLA_BALDR_CONNECTIVITY_MAP_H_
+#define VALHALLA_BALDR_CONNECTIVITY_MAP_H_
+
+#include "baldr/tilehierarchy.h"
+
+#include <vector>
+#include <unordered_map>
+#include <cstdint>
+
+namespace valhalla {
+  namespace baldr {
+    //TODO: maintain consistent coloring of regions despite the connectivity changing
+    class connectivity_map_t {
+     public:
+      /**
+       * Constructus the connectivity map
+       *
+       */
+      connectivity_map_t(const TileHierarchy& tile_hierarchy);
+
+      /**
+       * Returns the color for the given graphid
+       *
+       * @param id      the graphid
+       * @return color  the color
+       */
+      size_t get_color(const GraphId& id) const;
+
+      /**
+       * Returns the geojson representing the connectivity map
+       *
+       * @param hierarchy_level the hierarchy level whos connectivity you want to see
+       * @return string         the geojson
+       */
+      std::string to_geojson(const uint32_t hierarchy_level) const;
+
+      /**
+       * Returns the vector of colors (one per tile) representing the connectivity map
+       *
+       * @param hierarchy_level the hierarchy level whos connectivity you want to see
+       * @return vector         the vector of colors per tile
+       */
+      std::vector<size_t> to_image(const uint32_t hierarchy_level) const;
+
+     private:
+      std::unordered_map<uint32_t, std::unordered_map<uint32_t, size_t> > colors;
+      TileHierarchy tile_hierarchy;
+    };
+  }
+}
+
+#endif //VALHALLA_BALDR_CONNECTIVITY_MAP_H_

--- a/valhalla/baldr/graphreader.h
+++ b/valhalla/baldr/graphreader.h
@@ -32,22 +32,16 @@ class GraphReader {
   static bool DoesTileExist(const TileHierarchy& tile_hierarchy, const GraphId& graphid);
 
   /**
-   * Get a tile "map" - bool vector identifying which tiles exist.
-   * @param  level  Tile hierarchy level used to get the tile map.
-   * @return  Returns the tile map - vector of bool indicating which tiles
-   *          exist.
+   * Returns true connectivity exists between the two tile ids
+   * Note: the connectivity may not be routable or may fail for other reasons
+   * the expectation is that the caller knows that this is best case
+   * scenario. The main use case is to quickly reject two disjoint locations
+   *
+   * @param  GraphId  the first tile to check
+   * @param  GraphId  the second tile to check
+   * @return bool     whether or not they are in the same connected region
    */
-  std::vector<bool> TileMap(const uint32_t level);
-
-  /**
-   * Get a tile connectivity map. This is a vector where each tile Id is
-   * assigned an integer value. Connected tiles will have the same value
-   * while disconnected (no path using poulated tiles exists) will have
-   * different values.
-   * @param  level  Tile hierarchy level used to get the tile map.
-   * @return  Returns the tile connectivity map.
-   */
-  std::vector<uint32_t> ConnectivityMap(const uint32_t level);
+  bool AreConnected(const GraphId& first, const GraphId& second) const;
 
   /**
    * Get a pointer to a graph tile object given a GraphId.

--- a/valhalla/baldr/graphtile.h
+++ b/valhalla/baldr/graphtile.h
@@ -56,9 +56,10 @@ class GraphTile {
   /**
    * Get the tile Id given the full path to the file.
    * @param  fname  Filename with complete path.
+   * @param  hierarchy the tile hierarchy this tile is under
    * @return  Returns the tile Id.
    */
-  static GraphId GetTileId(const std::string& fname);
+  static GraphId GetTileId(const std::string& fname, const TileHierarchy& hierarchy);
 
   /**
    * Gets the size of the tile in bytes. A value of 0 indicates an empty tile. A value


### PR DESCRIPTION
moved the connectivity map into a singleton in graphgreader. it gets configured once and used everywhere. also changed the reverse mapping of file name string to graphid (was previously hardcoded to be level two with .25 degrees or whatever we have in our configs)

with test yay