### PR TITLE
Fix TransitDeparture and move to using line Id rather than edge Id

### DIFF
--- a/src/baldr/directededge.cc
+++ b/src/baldr/directededge.cc
@@ -180,6 +180,11 @@ Use DirectedEdge::use() const {
   return static_cast<Use>(attributes_.use);
 }
 
+// Is this edge a transit line (bus or rail)?
+bool DirectedEdge::IsTransitLine() const {
+  return (use() == Use::kRail || use() == Use::kBus);
+}
+
 // Get the speed type (see graphconstants.h)
 SpeedType DirectedEdge::speed_type() const {
   return static_cast<SpeedType>(attributes_.speed_type);
@@ -251,12 +256,17 @@ bool DirectedEdge::edge_to_left(const uint32_t localidx) const {
 uint32_t DirectedEdge::stopimpact(const uint32_t localidx) const {
   // Stop impact is 3 bits per index
   uint32_t shift = localidx * 3;
-  return (stopimpact_.stopimpact & (7 << shift)) >> shift;
+  return (stopimpact_.s.stopimpact & (7 << shift)) >> shift;
+}
+
+// Get the transit line Id (for departure lookups along an edge)
+uint32_t DirectedEdge::lineid() const {
+  return stopimpact_.lineid;
 }
 
 // Is there an edge to the right, in between the from edge and this edge.
 bool DirectedEdge::edge_to_right(const uint32_t localidx) const {
-  return (stopimpact_.edge_to_right & (1 << localidx));
+  return (stopimpact_.s.edge_to_right & (1 << localidx));
 }
 
 // Get the index of the directed edge on the local level of the graph
@@ -421,10 +431,10 @@ const uint64_t DirectedEdge::internal_version() {
   boost::hash_combine(seed,ffs(de.turntypes_.edge_to_left+1)-1);
 
   // Stop impact
-  de.stopimpact_.stopimpact = ~de.stopimpact_.stopimpact;
-  boost::hash_combine(seed,ffs(de.stopimpact_.stopimpact+1)-1);
-  de.stopimpact_.edge_to_right = ~de.stopimpact_.edge_to_right;
-  boost::hash_combine(seed,ffs(de.stopimpact_.edge_to_right+1)-1);
+  de.stopimpact_.s.stopimpact = ~de.stopimpact_.s.stopimpact;
+  boost::hash_combine(seed,ffs(de.stopimpact_.s.stopimpact+1)-1);
+  de.stopimpact_.s.edge_to_right = ~de.stopimpact_.s.edge_to_right;
+  boost::hash_combine(seed,ffs(de.stopimpact_.s.edge_to_right+1)-1);
 
   // Hierarchy and shortcut information
   de.hierarchy_.localedgeidx = ~de.hierarchy_.localedgeidx;

--- a/src/baldr/graphtile.cc
+++ b/src/baldr/graphtile.cc
@@ -383,7 +383,7 @@ std::vector<SignInfo> GraphTile::GetSigns(const uint32_t idx) const {
 
 // Get the next departure given the directed edge Id and the current
 // time (seconds from midnight).
-const TransitDeparture* GraphTile::GetNextDeparture(const uint32_t edgeid,
+const TransitDeparture* GraphTile::GetNextDeparture(const uint32_t lineid,
                  const uint32_t current_time, const uint32_t date,
                  const uint32_t dow) const {
   uint32_t count = header_->departurecount();
@@ -399,11 +399,11 @@ const TransitDeparture* GraphTile::GetNextDeparture(const uint32_t edgeid,
   bool found = false;
   while (low <= high) {
     mid = (low + high) / 2;
-    if (departures_[mid].edgeid() == edgeid) {
+    if (departures_[mid].lineid() == lineid) {
       found = true;
       break;
     }
-    if (edgeid < departures_[mid].edgeid() ) {
+    if (lineid < departures_[mid].lineid() ) {
       high = mid - 1;
     } else {
       low = mid + 1;
@@ -411,14 +411,14 @@ const TransitDeparture* GraphTile::GetNextDeparture(const uint32_t edgeid,
   }
 
   if (!found) {
-    LOG_INFO("No departures  found for edgeid = " + std::to_string(edgeid));
+    LOG_WARN("No departures found for lineid = " + std::to_string(lineid));
     return nullptr;
   }
 
   // Back up until the prior departure from this edge has departure time
   // less than the current time
   while (mid > 0 &&
-         departures_[mid-1].edgeid() == edgeid &&
+         departures_[mid-1].lineid() == lineid &&
          departures_[mid-1].departure_time() >= current_time) {
     mid--;
   }
@@ -458,8 +458,9 @@ const TransitDeparture* GraphTile::GetNextDeparture(const uint32_t edgeid,
       }
     }
 
+
     // Advance to next departure
-    if (mid+1 < count && departures_[mid+1].edgeid() == edgeid) {
+    if (mid+1 < count && departures_[mid+1].lineid() == lineid) {
       mid++;
     } else {
       break;
@@ -467,12 +468,13 @@ const TransitDeparture* GraphTile::GetNextDeparture(const uint32_t edgeid,
   }
 
   // TODO - maybe wrap around, try next day?
-  LOG_WARN("No more departures found for edgeid = " + std::to_string(edgeid));
+  LOG_WARN("No more departures found for lineid = " + std::to_string(lineid));
   return nullptr;
 }
 
-// Get the departure given the directed edge Id and tripid
-const TransitDeparture* GraphTile::GetTransitDeparture(const uint32_t edgeid,const uint32_t tripid) const {
+// Get the departure given the line Id and tripid
+const TransitDeparture* GraphTile::GetTransitDeparture(const uint32_t lineid,
+                     const uint32_t tripid) const {
   uint32_t count = header_->departurecount();
   if (count == 0) {
     return nullptr;
@@ -486,11 +488,11 @@ const TransitDeparture* GraphTile::GetTransitDeparture(const uint32_t edgeid,con
   bool found = false;
   while (low <= high) {
     mid = (low + high) / 2;
-    if (departures_[mid].edgeid() == edgeid) {
+    if (departures_[mid].lineid() == lineid) {
       found = true;
       break;
     }
-    if (edgeid < departures_[mid].edgeid() ) {
+    if (lineid < departures_[mid].lineid() ) {
       high = mid - 1;
     } else {
       low = mid + 1;
@@ -498,14 +500,14 @@ const TransitDeparture* GraphTile::GetTransitDeparture(const uint32_t edgeid,con
   }
 
   if (!found) {
-    LOG_INFO("No departures found for edgeid = " + std::to_string(edgeid) +
+    LOG_INFO("No departures found for lineid = " + std::to_string(lineid) +
              " and tripid = " + std::to_string(tripid));
     return nullptr;
   }
 
   if (found) {
     // Back up while prior is equal (or at the beginning)
-    while (mid > 0 && departures_[mid-1].edgeid() == edgeid) {
+    while (mid > 0 && departures_[mid-1].lineid() == lineid) {
 
       if (departures_[mid].tripid() == tripid)
         return &departures_[mid];
@@ -521,7 +523,7 @@ const TransitDeparture* GraphTile::GetTransitDeparture(const uint32_t edgeid,con
       return &departures_[mid];
   }
 
-  LOG_INFO("No departures found for edgeid = " + std::to_string(edgeid) +
+  LOG_INFO("No departures found for lineid = " + std::to_string(lineid) +
            " and tripid = " + std::to_string(tripid));
   return nullptr;
 }

--- a/src/baldr/transitdeparture.cc
+++ b/src/baldr/transitdeparture.cc
@@ -4,31 +4,34 @@ namespace valhalla {
 namespace baldr {
 
 // Construct with arguments
-TransitDeparture::TransitDeparture(const uint32_t edgeid, const uint32_t tripid,
-                 const uint32_t routeid, const uint32_t blockid,
+TransitDeparture::TransitDeparture(const uint32_t lineid,
+                 const uint32_t tripid, const uint32_t routeid,
+                 const uint32_t blockid,
                  const uint32_t headsign_offset,
                  const uint32_t departure_time,
                  const uint32_t elapsed_time,
                  const uint32_t start_date,
                  const uint32_t end_date, const uint32_t days,
                  const uint32_t serviceid)
-    : edgeid_(edgeid),
+    : lineid_(lineid),
       tripid_(tripid),
       routeid_(routeid),
       blockid_(blockid),
       headsign_offset_(headsign_offset),
       serviceid_(serviceid) {
+  // TODO - protect against max values...
   times_.departure = departure_time;
-  times_.elapsed   = elapsed_time;
+  uint32_t elapsed = (elapsed_time < 32767) ? elapsed_time : 32767;
+  times_.elapsed   = elapsed;
   dates_.start     = start_date;
   dates_.end       = end_date;
   dates_.days      = days;
 }
 
-// Get the edge Id - for lookup of all departures along this edge. Each edge
+// Get the line Id - for lookup of all departures along an edge. Each line Id
 // represents a unique departure/arrival stop pair and route Id.
-uint32_t TransitDeparture::edgeid() const {
-  return edgeid_;
+uint32_t TransitDeparture::lineid() const {
+  return lineid_;
 }
 
 // Get the internal trip Id for this departure.
@@ -81,12 +84,12 @@ uint32_t TransitDeparture::serviceid() const {
   return serviceid_;
 }
 
-// operator < - for sorting. Sort by edge Id and departure time.
+// operator < - for sorting. Sort by line Id and departure time.
 bool TransitDeparture::operator < (const TransitDeparture& other) const {
-  if (edgeid() == other.edgeid()) {
+  if (lineid() == other.lineid()) {
     return departure_time() < other.departure_time();
   } else {
-    return edgeid() < other.edgeid();
+    return lineid() < other.lineid();
   }
 }
 

--- a/valhalla/baldr/directededge.h
+++ b/valhalla/baldr/directededge.h
@@ -250,6 +250,12 @@ class DirectedEdge {
   Use use() const;
 
   /**
+   * Is this edge a transit line (bus or rail)?
+   * @return  Returns true if this edge is a transit line.
+   */
+  bool IsTransitLine() const;
+
+  /**
    * Get the speed type (see graphconstants.h)
    * @return  Returns the speed type.
    */
@@ -330,6 +336,12 @@ class DirectedEdge {
    * @return  Returns the relative stop impact from low (0) to high (7).
    */
   uint32_t stopimpact(const uint32_t localidx) const;
+
+  /**
+   * Get the transit line Id (for departure lookups along an edge)
+   * @return  Returns the transit line Id.
+   */
+  uint32_t lineid() const;
 
   /**
    * Is there an edge to the right, in between the from edge and this edge.
@@ -501,7 +513,15 @@ class DirectedEdge {
     uint32_t edge_to_right   :  8; // Is there an edge to the right (between
                                    // "from edge" and this edge)
   };
-  StopImpact stopimpact_;
+
+  // Store either the stop impact or the transit line identifier. Since
+  // transit lines are schedule based they have no need for edge transition
+  // logic so we can safely share this field.
+  union StopOrLine {
+    StopImpact s;
+    uint32_t   lineid;
+  };
+  StopOrLine stopimpact_;
 
   // Hierarchy transitions and shortcut information
   struct Hierarchy {

--- a/valhalla/baldr/graphconstants.h
+++ b/valhalla/baldr/graphconstants.h
@@ -119,15 +119,15 @@ enum class Use : uint8_t {
   kCycleway = 20,          // Dedicated bicycle path
   kMountainBike = 21,      // Mountain bike trail
 
-  // Transit specific uses
-  kRail = 30,              // Rail line
-  kBus = 31,               // Bus line
-  kRailConnection = 32,    // Connection to a rail stop
-  kBusConnection = 33,     // Connection to a bus stop
-  kTransitConnection = 34, // Connection to multi-use transit stop
-
   // Other...
-  kOther = 63
+  kOther = 40,
+
+  // Transit specific uses. Must be last in the list
+  kRail = 50,              // Rail line
+  kBus = 51,               // Bus line
+  kRailConnection = 52,    // Connection to a rail stop
+  kBusConnection = 53,     // Connection to a bus stop
+  kTransitConnection = 54  // Connection to multi-use transit stop
 };
 
 // Speed type

--- a/valhalla/baldr/transitdeparture.h
+++ b/valhalla/baldr/transitdeparture.h
@@ -14,7 +14,7 @@ namespace baldr {
 class TransitDeparture {
  public:
   // Construct with arguments
-  TransitDeparture(const uint32_t edgeid, const uint32_t tripid,
+  TransitDeparture(const uint32_t lineid, const uint32_t tripid,
                    const uint32_t routeid, const uint32_t blockid,
                    const uint32_t headsign_offset,
                    const uint32_t departure_time,
@@ -24,11 +24,11 @@ class TransitDeparture {
                    const uint32_t serviceid);
 
   /**
-   * Get the edge Id - for lookup of all departures along this edge. Each edge
-   * represents a unique departure/arrival stop pair and route Id.
-   * @return  Returns the departure stop Id.
+   * Get the line Id - for lookup of all departures along this edge. Each
+   * line Id represents a unique departure/arrival stop pair and route Id.
+   * @return  Returns the departure line Id.
    */
-  uint32_t edgeid() const;
+  uint32_t lineid() const;
 
   /**
    * Get the internal trip Id for this departure.
@@ -93,17 +93,17 @@ class TransitDeparture {
   uint32_t serviceid() const;
 
   /**
-   * operator < - for sorting. Sort by edge Id and departure time.
+   * operator < - for sorting. Sort by line Id and departure time.
    * @param  other  Other transit departure to compare to.
-   * @return  Returns true if edge Id < other edge Id or if edge Ids are
+   * @return  Returns true if line Id < other line Id or if line Ids are
    *          equal and departure < other departure.
    */
   bool operator < (const TransitDeparture& other) const;
 
  protected:
-  // Edge Id - lookup departures by unique edge Id (which indicates a unique
+  // Line Id - lookup departures by unique line Id (which indicates a unique
   // departure / arrival stop pair.
-  uint32_t edgeid_;
+  uint32_t lineid_;
 
   // TripId (internal).
   uint32_t tripid_;
@@ -124,7 +124,7 @@ class TransitDeparture {
   };
   ScheduleTimes times_;
 
-  union ScheduleDates {
+  struct ScheduleDates {
     uint32_t start   : 12;     // Start date for the scheduled departure
     uint32_t end     : 12;     // End date for the scheduled departure
     uint32_t days    : 7;      // Days of the week


### PR DESCRIPTION
Store a unique line Id in directed edges and use that rather than the directed edge Id.
Fix a bug with TransitDeparture (used a union rather than struct for ScheduleDates).
Update transit use values to be at the upper end of the range.