### PR TITLE
Use std::nullptr_t instead of nullptr_t.

### DIFF
--- a/valhalla/baldr/json.h
+++ b/valhalla/baldr/json.h
@@ -29,7 +29,7 @@ struct fp_t {
 };
 
 //a variant of all the possible values to go with keys in json
-using Value = boost::variant<std::string, uint64_t, int64_t, fp_t, bool, nullptr_t, MapPtr, ArrayPtr>;
+using Value = boost::variant<std::string, uint64_t, int64_t, fp_t, bool, std::nullptr_t, MapPtr, ArrayPtr>;
 
 //the map value type in json
 class Jmap : public std::unordered_map<std::string, Value> {
@@ -83,7 +83,7 @@ class OstreamVisitor : public boost::static_visitor<std::ostream&>
   std::ostream& operator()(int64_t value) const { return ostream_ << value; }
   std::ostream& operator()(fp_t value) const { return ostream_ << value; }
   std::ostream& operator()(bool value) const { return ostream_ << (value ? "true" : "false"); }
-  std::ostream& operator()(nullptr_t value) const { return ostream_ << "null"; }
+  std::ostream& operator()(std::nullptr_t value) const { return ostream_ << "null"; }
   std::ostream& operator()(const MapPtr& value) const { return ostream_ << *value; }
   std::ostream& operator()(const ArrayPtr& value) const { return ostream_ << *value; }
  private:


### PR DESCRIPTION
Fixes a compile errror on OpenBSD with boost-1.58:

```
c++ -DHAVE_CONFIG_H -I. -I./valhalla -pthread -I/usr/local/include -Ivalhalla -O2 -pipe -g -std=c++11 -MT src/baldr/libvalhalla_baldr_la-connectivity_map.lo -MD -MP -MF src/baldr/.deps/libvalhalla_baldr_la-connectivity_map.Tpo -c src/baldr/connectivity_map.cc -fPIC -DPIC -o src/baldr/.libs/libvalhalla_baldr_la-connectivity_map.o
In file included from src/baldr/connectivity_map.cc:2:0:
./valhalla/baldr/json.h:32:74: error: 'nullptr_t' was not declared in this scope
 using Value = boost::variant<std::string, uint64_t, int64_t, fp_t, bool, nullptr_t, MapPtr, ArrayPtr>;
```