### PR TITLE
Add method to get opposing directed edge 

### DIFF
--- a/src/baldr/graphreader.cc
+++ b/src/baldr/graphreader.cc
@@ -94,15 +94,26 @@ bool GraphReader::OverCommitted() const {
   return max_cache_size_ < cache_size_;
 }
 
-// Convenience method to get an opposing directed edge.
+// Convenience method to get an opposing directed edge graph Id.
 GraphId GraphReader::GetOpposingEdgeId(const GraphId& edgeid) {
-  auto* directededge = GetGraphTile(edgeid)->directededge(edgeid);
+  const auto* directededge = GetGraphTile(edgeid)->directededge(edgeid);
   GraphId endnodeid = directededge->endnode();
-  auto* endnode = GetGraphTile(endnodeid)->node(endnodeid);
-  GraphId opposing_edge_id;
-  opposing_edge_id.Set(endnodeid.tileid(), endnodeid.level(),
+  const auto* tile = GetGraphTile(endnodeid);
+  GraphId opposing_edge_id = { };
+  if (tile != nullptr) {
+    const auto* endnode = GetGraphTile(endnodeid)->node(endnodeid);
+    opposing_edge_id.Set(endnodeid.tileid(), endnodeid.level(),
                        endnode->edge_index() + directededge->opp_index());
+  }
   return opposing_edge_id;
+}
+
+// Convenience method to get an opposing directed edge.
+const DirectedEdge* GraphReader::GetOpposingEdge(const GraphId& edgeid) {
+  GraphId oppedgeid = GetOpposingEdgeId(edgeid);
+  return (oppedgeid.Is_Valid()) ?
+      GetGraphTile(oppedgeid)->directededge(oppedgeid): nullptr;
+
 }
 
 

--- a/valhalla/baldr/graphreader.h
+++ b/valhalla/baldr/graphreader.h
@@ -85,9 +85,21 @@ class GraphReader {
   /**
    * Convenience method to get an opposing directed edge.
    * @param  edgeid  Graph Id of the directed edge.
-   * @return  Returns the graph Id of the opposing directed edge.
+   * @return  Returns the graph Id of the opposing directed edge. An
+   *          invalid graph Id is returned if the opposing edge does not
+   *          exist (can occur with a regional extract where adjacent tile
+   *          is missing).
    */
   GraphId GetOpposingEdgeId(const GraphId& edgeid);
+
+  /**
+   * Convenience method to get an opposing directed edge.
+   * @param  edgeid  Graph Id of the directed edge.
+   * @return  Returns the opposing directed edge or nullptr if the
+   *          opposing edge does not exist (can occur with a regional extract
+   *          where the adjacent tile is missing)
+   */
+  const DirectedEdge* GetOpposingEdge(const GraphId& edgeid);
 
  protected:
   // Information about where the tiles are kept


### PR DESCRIPTION
and protect opposing edge methods from an invalid graph Id (if adjacent tile is empty).