### PR TITLE
Improved TTS for county route/roads, state routes, farm to market roads, and ranch to market roads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ test/turn
 test/json
 test/verbal_text_formatter
 test/verbal_text_formatter_us
+test/verbal_text_formatter_us_co
 test/*.log
 test/*.trs
 

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ test/json
 test/verbal_text_formatter
 test/verbal_text_formatter_us
 test/verbal_text_formatter_us_co
+test/verbal_text_formatter_us_tx
 test/*.log
 test/*.trs
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -72,6 +72,7 @@ nobase_include_HEADERS = \
 	valhalla/baldr/verbal_text_formatter.h \
 	valhalla/baldr/verbal_text_formatter_us.h \
 	valhalla/baldr/verbal_text_formatter_us_co.h \
+	valhalla/baldr/verbal_text_formatter_us_tx.h \
 	valhalla/baldr/verbal_text_formatter_factory.h
 libvalhalla_baldr_la_SOURCES = \
         src/baldr/admin.cc \
@@ -106,6 +107,7 @@ libvalhalla_baldr_la_SOURCES = \
 	src/baldr/verbal_text_formatter.cc \
 	src/baldr/verbal_text_formatter_us.cc \
 	src/baldr/verbal_text_formatter_us_co.cc \
+	src/baldr/verbal_text_formatter_us_tx.cc \
 	src/baldr/verbal_text_formatter_factory.cc
 libvalhalla_baldr_la_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_CPPFLAGS) @BOOST_CPPFLAGS@
 libvalhalla_baldr_la_LIBADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) @BOOST_LDFLAGS@ $(BOOST_SYSTEM_LIB) $(BOOST_FILESYSTEM_LIB) $(BOOST_THREAD_LIB) $(BOOST_SERIALIZATION_LIB) $(BOOST_DATE_TIME_LIB)
@@ -136,7 +138,8 @@ check_PROGRAMS = \
 	test/json \
 	test/verbal_text_formatter \
 	test/verbal_text_formatter_us \
-	test/verbal_text_formatter_us_co
+	test/verbal_text_formatter_us_co \
+	test/verbal_text_formatter_us_tx
 test_location_SOURCES = test/location.cc test/test.cc
 test_location_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_CPPFLAGS)
 test_location_LDADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) libvalhalla_baldr.la
@@ -191,6 +194,9 @@ test_verbal_text_formatter_us_LDADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) libvalhal
 test_verbal_text_formatter_us_co_SOURCES = test/verbal_text_formatter_us_co.cc test/test.cc
 test_verbal_text_formatter_us_co_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_CPPFLAGS)
 test_verbal_text_formatter_us_co_LDADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) libvalhalla_baldr.la
+test_verbal_text_formatter_us_tx_SOURCES = test/verbal_text_formatter_us_tx.cc test/test.cc
+test_verbal_text_formatter_us_tx_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_CPPFLAGS)
+test_verbal_text_formatter_us_tx_LDADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) libvalhalla_baldr.la
 
 
 TESTS = $(check_PROGRAMS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -71,6 +71,7 @@ nobase_include_HEADERS = \
 	valhalla/baldr/transittrip.h \
 	valhalla/baldr/verbal_text_formatter.h \
 	valhalla/baldr/verbal_text_formatter_us.h \
+	valhalla/baldr/verbal_text_formatter_us_co.h \
 	valhalla/baldr/verbal_text_formatter_factory.h
 libvalhalla_baldr_la_SOURCES = \
         src/baldr/admin.cc \
@@ -104,6 +105,7 @@ libvalhalla_baldr_la_SOURCES = \
 	src/baldr/transittrip.cc \
 	src/baldr/verbal_text_formatter.cc \
 	src/baldr/verbal_text_formatter_us.cc \
+	src/baldr/verbal_text_formatter_us_co.cc \
 	src/baldr/verbal_text_formatter_factory.cc
 libvalhalla_baldr_la_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_CPPFLAGS) @BOOST_CPPFLAGS@
 libvalhalla_baldr_la_LIBADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) @BOOST_LDFLAGS@ $(BOOST_SYSTEM_LIB) $(BOOST_FILESYSTEM_LIB) $(BOOST_THREAD_LIB) $(BOOST_SERIALIZATION_LIB) $(BOOST_DATE_TIME_LIB)
@@ -133,7 +135,8 @@ check_PROGRAMS = \
 	test/streetnames_factory \
 	test/json \
 	test/verbal_text_formatter \
-	test/verbal_text_formatter_us
+	test/verbal_text_formatter_us \
+	test/verbal_text_formatter_us_co
 test_location_SOURCES = test/location.cc test/test.cc
 test_location_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_CPPFLAGS)
 test_location_LDADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) libvalhalla_baldr.la
@@ -185,6 +188,9 @@ test_verbal_text_formatter_LDADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) libvalhalla_
 test_verbal_text_formatter_us_SOURCES = test/verbal_text_formatter_us.cc test/test.cc
 test_verbal_text_formatter_us_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_CPPFLAGS)
 test_verbal_text_formatter_us_LDADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) libvalhalla_baldr.la
+test_verbal_text_formatter_us_co_SOURCES = test/verbal_text_formatter_us_co.cc test/test.cc
+test_verbal_text_formatter_us_co_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_CPPFLAGS)
+test_verbal_text_formatter_us_co_LDADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) libvalhalla_baldr.la
 
 
 TESTS = $(check_PROGRAMS)

--- a/src/baldr/verbal_text_formatter_factory.cc
+++ b/src/baldr/verbal_text_formatter_factory.cc
@@ -1,5 +1,6 @@
 #include "baldr/verbal_text_formatter.h"
 #include "baldr/verbal_text_formatter_us.h"
+#include "baldr/verbal_text_formatter_us_co.h"
 #include "baldr/verbal_text_formatter_factory.h"
 #include <valhalla/midgard/util.h>
 
@@ -9,6 +10,10 @@ namespace baldr {
 std::unique_ptr<VerbalTextFormatter> VerbalTextFormatterFactory::Create(
     const std::string& country_code, const std::string& state_code) {
   if (country_code == "US") {
+    if (state_code == "CO") {
+      return midgard::make_unique<VerbalTextFormatterUsCo>(country_code,
+                                                           state_code);
+    }
     return midgard::make_unique<VerbalTextFormatterUs>(country_code, state_code);
   }
 

--- a/src/baldr/verbal_text_formatter_factory.cc
+++ b/src/baldr/verbal_text_formatter_factory.cc
@@ -1,6 +1,7 @@
 #include "baldr/verbal_text_formatter.h"
 #include "baldr/verbal_text_formatter_us.h"
 #include "baldr/verbal_text_formatter_us_co.h"
+#include "baldr/verbal_text_formatter_us_tx.h"
 #include "baldr/verbal_text_formatter_factory.h"
 #include <valhalla/midgard/util.h>
 
@@ -10,7 +11,10 @@ namespace baldr {
 std::unique_ptr<VerbalTextFormatter> VerbalTextFormatterFactory::Create(
     const std::string& country_code, const std::string& state_code) {
   if (country_code == "US") {
-    if (state_code == "CO") {
+    if (state_code == "TX") {
+      return midgard::make_unique<VerbalTextFormatterUsTx>(country_code,
+                                                           state_code);
+    } else if (state_code == "CO") {
       return midgard::make_unique<VerbalTextFormatterUsCo>(country_code,
                                                            state_code);
     }

--- a/src/baldr/verbal_text_formatter_us.cc
+++ b/src/baldr/verbal_text_formatter_us.cc
@@ -26,7 +26,7 @@ std::string VerbalTextFormatterUs::Format(const std::string& text) const {
   // TODO township T >> Township or not
   // TODO FM farm to market, others? TR?
 
-  verbal_text = FormThousandTts(verbal_text);
+  verbal_text = ProcessThousandTts(verbal_text);
   verbal_text = ProcessHundredTts(verbal_text);
   verbal_text = FormNumberSplitTts(verbal_text);
   verbal_text = FormLeadingOhTts(verbal_text);
@@ -134,9 +134,21 @@ bool VerbalTextFormatterUs::FormCountyTts(
   return (tts != source);
 }
 
-std::string VerbalTextFormatterUs::FormThousandTts(
+std::string VerbalTextFormatterUs::ProcessThousandTts(
     const std::string& source) const {
-  return std::regex_replace(source, kThousandRegex, kThousandOutPattern);
+
+  std::string tts = source;
+  for (auto& thousand_find_replace : kThousandFindReplace) {
+    tts = FormThousandTts(tts, thousand_find_replace.first,
+                          thousand_find_replace.second);
+  }
+  return tts;
+}
+
+std::string VerbalTextFormatterUs::FormThousandTts(
+    const std::string& source, const std::regex& thousand_regex,
+    const std::string& thousand_output_pattern) const {
+  return std::regex_replace(source, thousand_regex, thousand_output_pattern);
 }
 
 std::string VerbalTextFormatterUs::ProcessHundredTts(

--- a/src/baldr/verbal_text_formatter_us.cc
+++ b/src/baldr/verbal_text_formatter_us.cc
@@ -27,7 +27,7 @@ std::string VerbalTextFormatterUs::Format(const std::string& text) const {
   // TODO FM farm to market, others? TR?
 
   verbal_text = FormThousandTts(verbal_text);
-  verbal_text = FormHundredTts(verbal_text);
+  verbal_text = ProcessHundredTts(verbal_text);
   verbal_text = FormNumberSplitTts(verbal_text);
   verbal_text = FormLeadingOhTts(verbal_text);
 
@@ -139,9 +139,21 @@ std::string VerbalTextFormatterUs::FormThousandTts(
   return std::regex_replace(source, kThousandRegex, kThousandOutPattern);
 }
 
-std::string VerbalTextFormatterUs::FormHundredTts(
+std::string VerbalTextFormatterUs::ProcessHundredTts(
     const std::string& source) const {
-  return std::regex_replace(source, kHundredRegex, kHundredOutPattern);
+
+  std::string tts = source;
+  for (auto& hundred_find_replace : kHundredFindReplace) {
+    tts = FormHundredTts(tts, hundred_find_replace.first,
+                         hundred_find_replace.second);
+  }
+  return tts;
+}
+
+std::string VerbalTextFormatterUs::FormHundredTts(
+    const std::string& source, const std::regex& hundred_regex,
+    const std::string& hundred_output_pattern) const {
+  return std::regex_replace(source, hundred_regex, hundred_output_pattern);
 }
 
 std::string VerbalTextFormatterUs::FormLeadingOhTts(
@@ -151,3 +163,4 @@ std::string VerbalTextFormatterUs::FormLeadingOhTts(
 
 }
 }
+

--- a/src/baldr/verbal_text_formatter_us_co.cc
+++ b/src/baldr/verbal_text_formatter_us_co.cc
@@ -1,0 +1,32 @@
+#include <iostream>
+#include <memory>
+
+#include "baldr/verbal_text_formatter.h"
+#include "baldr/verbal_text_formatter_us.h"
+#include "baldr/verbal_text_formatter_us_co.h"
+#include <valhalla/midgard/util.h>
+
+namespace valhalla {
+namespace baldr {
+
+VerbalTextFormatterUsCo::VerbalTextFormatterUsCo(const std::string& country_code,
+                                             const std::string& state_code)
+    : VerbalTextFormatterUs(country_code, state_code) {
+}
+
+VerbalTextFormatterUsCo::~VerbalTextFormatterUsCo() {
+}
+
+std::string VerbalTextFormatterUsCo::ProcessStatesTts(
+    const std::string& source) const {
+
+  std::string tts;
+  if (FormStateTts(source, kColoradoRegex, kColoradoOutPattern, tts)) {
+    // Colorado has been found and transformed - so return
+    return tts;
+  }
+  return VerbalTextFormatterUs::ProcessStatesTts(source);
+}
+
+}
+}

--- a/src/baldr/verbal_text_formatter_us_tx.cc
+++ b/src/baldr/verbal_text_formatter_us_tx.cc
@@ -1,0 +1,38 @@
+#include <iostream>
+#include <memory>
+
+#include "baldr/verbal_text_formatter.h"
+#include "baldr/verbal_text_formatter_us.h"
+#include "baldr/verbal_text_formatter_us_tx.h"
+#include <valhalla/midgard/util.h>
+
+namespace valhalla {
+namespace baldr {
+
+VerbalTextFormatterUsTx::VerbalTextFormatterUsTx(
+    const std::string& country_code, const std::string& state_code)
+    : VerbalTextFormatterUs(country_code, state_code) {
+}
+
+VerbalTextFormatterUsTx::~VerbalTextFormatterUsTx() {
+}
+
+std::string VerbalTextFormatterUsTx::Format(const std::string& text) const {
+  std::string verbal_text(text);
+  verbal_text = FormFmTts(verbal_text);
+  verbal_text = FormRmTts(verbal_text);
+  verbal_text = VerbalTextFormatterUs::Format(verbal_text);
+  return verbal_text;
+}
+
+std::string VerbalTextFormatterUsTx::FormFmTts(
+    const std::string& source) const {
+  return std::regex_replace(source, kFmRegex, kFmOutPattern);
+}
+std::string VerbalTextFormatterUsTx::FormRmTts(
+    const std::string& source) const {
+  return std::regex_replace(source, kRmRegex, kRmOutPattern);
+}
+
+}
+}

--- a/test/verbal_text_formatter_us.cc
+++ b/test/verbal_text_formatter_us.cc
@@ -367,6 +367,10 @@ void TestFormat() {
   TryFormat("SR-1021", "State Route 10 21");
   TryFormat("Sr 1021", "State Route 10 21");
   TryFormat("SR3032", "State Route 30 32");
+  TryFormat("SH 1021", "State Highway 10 21");
+  TryFormat("SH-1021", "State Highway 10 21");
+  TryFormat("Sh 1021", "State Highway 10 21");
+  TryFormat("SH3032", "State Highway 30 32");
   TryFormat("CT 14A", "Connecticut 14A");
 
   TryFormat("CR 0", "County Route 0");

--- a/test/verbal_text_formatter_us.cc
+++ b/test/verbal_text_formatter_us.cc
@@ -98,7 +98,7 @@ void TryProcessStatesTts(string source, string expected) {
   string tts = formatter_test.ProcessStatesTts(source);
   if (tts != expected) {
     throw std::runtime_error(
-        "Incorrect FormUsHighwayTts - EXPECTED: " + expected + "  |  FORMED: " + tts);
+        "Incorrect ProcessStatesTts - EXPECTED: " + expected + "  |  FORMED: " + tts);
   }
 }
 
@@ -109,7 +109,7 @@ void TestProcessStatesTts() {
   TryProcessStatesTts("AK 1", "Alaska 1");
   TryProcessStatesTts("AR 107", "Arkansas 107");
   TryProcessStatesTts("CA 480", "California 480");
-  TryProcessStatesTts("CO 265", "Colorado 265");
+  TryProcessStatesTts("CO 265", "CO 265");
   TryProcessStatesTts("CT 14A", "Connecticut 14A");
   TryProcessStatesTts("CT 15", "Connecticut 15");
   TryProcessStatesTts("DE 10", "Delaware 10");
@@ -171,7 +171,7 @@ void TryProcessCountysTts(string source, string expected) {
   string tts = formatter_test.ProcessCountysTts(source);
   if (tts != expected) {
     throw std::runtime_error(
-        "Incorrect FormUsHighwayTts - EXPECTED: " + expected + "  |  FORMED: " + tts);
+        "Incorrect ProcessCountysTts - EXPECTED: " + expected + "  |  FORMED: " + tts);
   }
 }
 

--- a/test/verbal_text_formatter_us.cc
+++ b/test/verbal_text_formatter_us.cc
@@ -33,8 +33,8 @@ class VerbalTextFormatterUsTest : public VerbalTextFormatterUs {
     return VerbalTextFormatterUs::ProcessCountysTts(source);
   }
 
-  std::string FormThousandTts(const std::string& source) const {
-    return VerbalTextFormatterUs::FormThousandTts(source);
+  std::string ProcessThousandTts(const std::string& source) const {
+    return VerbalTextFormatterUs::ProcessThousandTts(source);
   }
 
   std::string ProcessHundredTts(const std::string& source) const {
@@ -207,7 +207,7 @@ void TestProcessCountysTts() {
 
 void TryFormThousandTtsString(string source, string expected) {
   VerbalTextFormatterUsTest formatter_test("US", "PA");
-  string tts = formatter_test.FormThousandTts(source);
+  string tts = formatter_test.ProcessThousandTts(source);
   if (tts != expected) {
     throw std::runtime_error(
         "Incorrect FormThousandTts - EXPECTED: " + expected + "  |  FORMED: " + tts);
@@ -218,6 +218,15 @@ void TestFormThousandTtsString() {
   TryFormThousandTtsString("1", "1");
   TryFormThousandTtsString("10", "10");
   TryFormThousandTtsString("1000", "1 thousand");
+  TryFormThousandTtsString("1000D", "1 thousand D");
+  TryFormThousandTtsString("D1000", "D1 thousand");
+  TryFormThousandTtsString("D1000D", "D1 thousand D");
+  TryFormThousandTtsString("3000-4000", "3 thousand 4 thousand");
+  TryFormThousandTtsString("53000-54000", "53 thousand 54 thousand");
+  TryFormThousandTtsString("Co 2000", "Co 2 thousand");
+  TryFormThousandTtsString("Co 2000A", "Co 2 thousand A");
+  TryFormThousandTtsString("Co A2000", "Co A2 thousand");
+  TryFormThousandTtsString("Co A2000A", "Co A2 thousand A");
   TryFormThousandTtsString("MD 1000", "MD 1 thousand");
   TryFormThousandTtsString("MD 1000 West", "MD 1 thousand West");
   TryFormThousandTtsString("24000", "24 thousand");
@@ -242,6 +251,7 @@ void TestFormHundredTtsString() {
   TryFormHundredTtsString("B100", "B1 hundred");
   TryFormHundredTtsString("B100B", "B1 hundred B");
   TryFormHundredTtsString("300-400", "3 hundred 4 hundred");
+  TryFormHundredTtsString("5300-5400", "53 hundred 54 hundred");
   TryFormHundredTtsString("Co 200", "Co 2 hundred");
   TryFormHundredTtsString("Co 200A", "Co 2 hundred A");
   TryFormHundredTtsString("Co A200", "Co A2 hundred");
@@ -383,6 +393,9 @@ void TestFormat() {
   TryFormat("Co 200", "County Road 2 hundred");
   TryFormat("Co 200A", "County Road 2 hundred A");
   TryFormat("Co 200BAD", "Co 2 hundred BAD");
+  TryFormat("Co 2000", "County Road 2 thousand");
+  TryFormat("Co 2000A", "County Road 2 thousand A");
+  TryFormat("Co 2000BAD", "Co 2 thousand BAD");
 
   TryFormat("T609", "T6 o9");
 }

--- a/test/verbal_text_formatter_us.cc
+++ b/test/verbal_text_formatter_us.cc
@@ -132,6 +132,8 @@ void TestProcessStatesTts() {
   TryProcessStatesTts("MN 55", "Minnesota 55");
   TryProcessStatesTts("MS 468", "Mississippi 468");
   TryProcessStatesTts("MO 180", "Missouri 180");
+  TryProcessStatesTts("MO A", "Missouri A");
+  TryProcessStatesTts("MO JJ", "Missouri JJ");
   TryProcessStatesTts("MT 282", "Montana 282");
   TryProcessStatesTts("NE 2", "Nebraska 2");
   TryProcessStatesTts("NE 55W Link", "Nebraska 55W Link");

--- a/test/verbal_text_formatter_us.cc
+++ b/test/verbal_text_formatter_us.cc
@@ -397,6 +397,12 @@ void TestFormat() {
   TryFormat("Co 2000A", "County Road 2 thousand A");
   TryFormat("Co 2000BAD", "Co 2 thousand BAD");
 
+  TryFormat("North 2800th", "North 28 hundredth");
+  TryFormat("North 2800th Avenue", "North 28 hundredth Avenue");
+
+  TryFormat("North 28000th", "North 28 thousandth");
+  TryFormat("North 28000th Avenue", "North 28 thousandth Avenue");
+
   TryFormat("T609", "T6 o9");
 }
 

--- a/test/verbal_text_formatter_us.cc
+++ b/test/verbal_text_formatter_us.cc
@@ -37,8 +37,8 @@ class VerbalTextFormatterUsTest : public VerbalTextFormatterUs {
     return VerbalTextFormatterUs::FormThousandTts(source);
   }
 
-  std::string FormHundredTts(const std::string& source) const {
-    return VerbalTextFormatterUs::FormHundredTts(source);
+  std::string ProcessHundredTts(const std::string& source) const {
+    return VerbalTextFormatterUs::ProcessHundredTts(source);
   }
 
   std::string FormNumberSplitTts(const std::string& source) const {
@@ -176,10 +176,32 @@ void TryProcessCountysTts(string source, string expected) {
 }
 
 void TestProcessCountysTts() {
+  TryProcessCountysTts("CR 0", "County Route 0");
+  TryProcessCountysTts("CR 1.00", "County Route 1.00");
+  TryProcessCountysTts("CR 100", "County Route 100");
+  TryProcessCountysTts("CR 100 S", "County Route 100 S");
   TryProcessCountysTts("CR 539", "County Route 539");
+  TryProcessCountysTts("CR-852", "County Route 852");
+  TryProcessCountysTts("C R A13", "County Route A13");
+  TryProcessCountysTts("C R 13B", "County Route 13B");
   TryProcessCountysTts("C R 404", "County Route 404");
   TryProcessCountysTts("CR-4003", "County Route 4003");
   TryProcessCountysTts("CR116", "County Route 116");
+  TryProcessCountysTts("CR A", "County Route A");
+  TryProcessCountysTts("CR JJ", "County Route JJ");
+  TryProcessCountysTts("CR J29", "County Route J29");
+  TryProcessCountysTts("CR 18VV", "County Route 18VV");
+  TryProcessCountysTts("Cr 8542 Marmot Trail", "County Route 8542 Marmot Trail");
+  TryProcessCountysTts("ACR 123", "ACR 123");
+  TryProcessCountysTts("A CR 123", "A County Route 123");
+  TryProcessCountysTts("CR Ettinger", "CR Ettinger");
+  TryProcessCountysTts("Crap", "Crap");
+  TryProcessCountysTts("Co 7", "County Road 7");
+  TryProcessCountysTts("Co-17", "County Road 17");
+  TryProcessCountysTts("Co39", "County Road 39");
+  TryProcessCountysTts("Co 200", "County Road 200");
+  TryProcessCountysTts("Co 200A", "County Road 200A");
+  TryProcessCountysTts("Co 200BAD", "Co 200BAD");
 
 }
 
@@ -205,7 +227,7 @@ void TestFormThousandTtsString() {
 
 void TryFormHundredTtsString(string source, string expected) {
   VerbalTextFormatterUsTest formatter_test("US", "MD");
-  string tts = formatter_test.FormHundredTts(source);
+  string tts = formatter_test.ProcessHundredTts(source);
   if (tts != expected) {
     throw std::runtime_error(
         "Incorrect FormHundredTts - EXPECTED: " + expected + "  |  FORMED: " + tts);
@@ -216,6 +238,14 @@ void TestFormHundredTtsString() {
   TryFormHundredTtsString("1", "1");
   TryFormHundredTtsString("10", "10");
   TryFormHundredTtsString("100", "1 hundred");
+  TryFormHundredTtsString("100B", "1 hundred B");
+  TryFormHundredTtsString("B100", "B1 hundred");
+  TryFormHundredTtsString("B100B", "B1 hundred B");
+  TryFormHundredTtsString("300-400", "3 hundred 4 hundred");
+  TryFormHundredTtsString("Co 200", "Co 2 hundred");
+  TryFormHundredTtsString("Co 200A", "Co 2 hundred A");
+  TryFormHundredTtsString("Co A200", "Co A2 hundred");
+  TryFormHundredTtsString("Co A200A", "Co A2 hundred A");
   TryFormHundredTtsString("MD 100", "MD 1 hundred");
   TryFormHundredTtsString("MD 100 West", "MD 1 hundred West");
   TryFormHundredTtsString("2400", "24 hundred");
@@ -329,8 +359,30 @@ void TestFormat() {
   TryFormat("SR3032", "State Route 30 32");
   TryFormat("CT 14A", "Connecticut 14A");
 
+  TryFormat("CR 0", "County Route 0");
+  TryFormat("CR 1.00", "County Route 1.00");
+  TryFormat("CR 100", "County Route 1 hundred");
+  TryFormat("CR 100 S", "County Route 1 hundred S");
   TryFormat("CR 539", "County Route 5 39");
+  TryFormat("CR-852", "County Route 8 52");
+  TryFormat("C R A13", "County Route A13");
+  TryFormat("C R 13B", "County Route 13B");
+  TryFormat("C R 404", "County Route 4 o4");
   TryFormat("CR-4003", "County Route 40 o3");
+  TryFormat("CR116", "County Route 1 16");
+  TryFormat("CR A", "County Route A");
+  TryFormat("CR JJ", "County Route JJ");
+  TryFormat("CR J29", "County Route J29");
+  TryFormat("CR 18VV", "County Route 18VV");
+  TryFormat("Cr 8542 Marmot Trail", "County Route 85 42 Marmot Trail");
+  TryFormat("CR Ettinger", "CR Ettinger");
+  TryFormat("Crap", "Crap");
+  TryFormat("Co 7", "County Road 7");
+  TryFormat("Co-17", "County Road 17");
+  TryFormat("Co39", "County Road 39");
+  TryFormat("Co 200", "County Road 2 hundred");
+  TryFormat("Co 200A", "County Road 2 hundred A");
+  TryFormat("Co 200BAD", "Co 2 hundred BAD");
 
   TryFormat("T609", "T6 o9");
 }

--- a/test/verbal_text_formatter_us.cc
+++ b/test/verbal_text_formatter_us.cc
@@ -355,6 +355,7 @@ void TestFormat() {
   TryFormat("US 202", "U.S. 2 o2");
   TryFormat("Us 422 Business Alternate", "U.S. 4 22 Business Alternate");
   TryFormat("Us-522", "U.S. 5 22");
+  TryFormat("US Highway 222", "U.S. Highway 2 22");
 
   TryFormat("AL 233", "Alabama 2 33");
   TryFormat("AR 107", "Arkansas 1 o7");
@@ -403,9 +404,11 @@ void TestFormat() {
 
   TryFormat("North 2800th", "North 28 hundredth");
   TryFormat("North 2800th Avenue", "North 28 hundredth Avenue");
+  TryFormat("North 2800Th Avenue", "North 28 hundredth Avenue");
 
   TryFormat("North 28000th", "North 28 thousandth");
   TryFormat("North 28000th Avenue", "North 28 thousandth Avenue");
+  TryFormat("North 28000TH Avenue", "North 28 thousandth Avenue");
 
   TryFormat("T609", "T6 o9");
 }

--- a/test/verbal_text_formatter_us.cc
+++ b/test/verbal_text_formatter_us.cc
@@ -133,7 +133,7 @@ void TestProcessStatesTts() {
   TryProcessStatesTts("MS 468", "Mississippi 468");
   TryProcessStatesTts("MO 180", "Missouri 180");
   TryProcessStatesTts("MO A", "Missouri A");
-  TryProcessStatesTts("MO JJ", "Missouri JJ");
+  TryProcessStatesTts("Mo JJ", "Missouri JJ");
   TryProcessStatesTts("MO JJ West", "Missouri JJ West");
   TryProcessStatesTts("Mo Money Road", "Mo Money Road");
   TryProcessStatesTts("MT 282", "Montana 282");

--- a/test/verbal_text_formatter_us.cc
+++ b/test/verbal_text_formatter_us.cc
@@ -134,6 +134,8 @@ void TestProcessStatesTts() {
   TryProcessStatesTts("MO 180", "Missouri 180");
   TryProcessStatesTts("MO A", "Missouri A");
   TryProcessStatesTts("MO JJ", "Missouri JJ");
+  TryProcessStatesTts("MO JJ West", "Missouri JJ West");
+  TryProcessStatesTts("Mo Money Road", "Mo Money Road");
   TryProcessStatesTts("MT 282", "Montana 282");
   TryProcessStatesTts("NE 2", "Nebraska 2");
   TryProcessStatesTts("NE 55W Link", "Nebraska 55W Link");

--- a/test/verbal_text_formatter_us_co.cc
+++ b/test/verbal_text_formatter_us_co.cc
@@ -1,0 +1,161 @@
+#include <regex>
+
+#include "test.h"
+#include "valhalla/baldr/verbal_text_formatter.h"
+#include "valhalla/baldr/verbal_text_formatter_us.h"
+#include "valhalla/baldr/verbal_text_formatter_us_co.h"
+
+using namespace std;
+using namespace valhalla::baldr;
+
+namespace {
+
+// Sub class to test protected methods
+class VerbalTextFormatterUsCoTest : public VerbalTextFormatterUsCo {
+ public:
+  VerbalTextFormatterUsCoTest(const std::string& country_code,
+                          const std::string& state_code)
+      : VerbalTextFormatterUsCo(country_code, state_code) {
+  }
+
+  std::string ProcessStatesTts(const std::string& source) const {
+    return VerbalTextFormatterUsCo::ProcessStatesTts(source);
+  }
+
+};
+
+void TryProcessStatesTts(string source, string expected) {
+  VerbalTextFormatterUsCoTest formatter_test("US", "CO");
+  string tts = formatter_test.ProcessStatesTts(source);
+  if (tts != expected) {
+    throw std::runtime_error(
+        "Incorrect ProcessStatesTts - EXPECTED: " + expected + "  |  FORMED: " + tts);
+  }
+}
+
+void TestProcessStatesTts() {
+  TryProcessStatesTts("AL 261", "Alabama 261");
+  TryProcessStatesTts("AL-261", "Alabama 261");
+  TryProcessStatesTts("Al 261", "Alabama 261");
+  TryProcessStatesTts("AK 1", "Alaska 1");
+  TryProcessStatesTts("AR 107", "Arkansas 107");
+  TryProcessStatesTts("CA 480", "California 480");
+  TryProcessStatesTts("CO 265", "Colorado 265");
+  TryProcessStatesTts("CT 14A", "Connecticut 14A");
+  TryProcessStatesTts("CT 15", "Connecticut 15");
+  TryProcessStatesTts("DE 10", "Delaware 10");
+  TryProcessStatesTts("DC 295", "D C 295");
+  TryProcessStatesTts("FL 535", "Florida 535");
+  TryProcessStatesTts("FL A1A", "Florida A1A");
+  TryProcessStatesTts("GA 400", "Georgia 400");
+  TryProcessStatesTts("HI 92", "Hawaii 92");
+  TryProcessStatesTts("ID 21", "Idaho 21");
+  TryProcessStatesTts("IL 97", "Illinois 97");
+  TryProcessStatesTts("IN 135", "Indiana 135");
+  TryProcessStatesTts("IA 5", "Iowa 5");
+  TryProcessStatesTts("KS 4", "Kansas 4");
+  TryProcessStatesTts("KY 676", "Kentucky 676");
+  TryProcessStatesTts("LA 73", "Louisiana 73");
+  TryProcessStatesTts("ME 27", "Maine 27");
+  TryProcessStatesTts("MD 450", "Maryland 450");
+  TryProcessStatesTts("MA 2", "Massachusetts 2");
+  TryProcessStatesTts("M 43", "Michigan 43");
+  TryProcessStatesTts("MN 55", "Minnesota 55");
+  TryProcessStatesTts("MS 468", "Mississippi 468");
+  TryProcessStatesTts("MO 180", "Missouri 180");
+  TryProcessStatesTts("MO A", "Missouri A");
+  TryProcessStatesTts("Mo JJ", "Missouri JJ");
+  TryProcessStatesTts("MO JJ West", "Missouri JJ West");
+  TryProcessStatesTts("Mo Money Road", "Mo Money Road");
+  TryProcessStatesTts("MT 282", "Montana 282");
+  TryProcessStatesTts("NE 2", "Nebraska 2");
+  TryProcessStatesTts("NE 55W Link", "Nebraska 55W Link");
+  TryProcessStatesTts("NV 592", "Nevada 592");
+  TryProcessStatesTts("NH 13", "New Hampshire 13");
+  TryProcessStatesTts("NJ 33", "New Jersey 33");
+  TryProcessStatesTts("NM 599", "New Mexico 599");
+  TryProcessStatesTts("NY 5", "New York 5");
+  TryProcessStatesTts("NC 50", "North Carolina 50");
+  TryProcessStatesTts("ND 810", "North Dakota 810");
+  TryProcessStatesTts("OH 73", "Ohio 73");
+  TryProcessStatesTts("OK 3", "Oklahoma 3");
+  TryProcessStatesTts("OR 99E Business", "Oregon 99E Business");
+  TryProcessStatesTts("PA 39", "Pennsylvania 39");
+  TryProcessStatesTts("RI 146", "Rhode Island 146");
+  TryProcessStatesTts("SC 12", "South Carolina 12");
+  TryProcessStatesTts("SD 34", "South Dakota 34");
+  TryProcessStatesTts("SD 1806", "South Dakota 1806");
+  TryProcessStatesTts("TN 155", "Tennessee 155");
+  TryProcessStatesTts("TX 165", "Texas 165");
+  TryProcessStatesTts("UT 186", "Utah 186");
+  TryProcessStatesTts("VT 12", "Vermont 12");
+  TryProcessStatesTts("VA 195", "Virginia 195");
+  TryProcessStatesTts("WA 8", "Washington 8");
+  TryProcessStatesTts("WV 7", "West Virginia 7");
+  TryProcessStatesTts("WI 30", "Wisconsin 30");
+  TryProcessStatesTts("WY 212", "Wyoming 212");
+
+}
+
+void TryFormat(string source, string expected) {
+  VerbalTextFormatterUsCoTest formatter_test("US", "CO");
+  string tts = formatter_test.Format(source);
+  if (tts != expected) {
+    throw std::runtime_error(
+        "Incorrect Format - EXPECTED: " + expected + "  |  FORMED: " + tts);
+  }
+}
+
+void TestFormat() {
+  TryFormat("I H1", "Interstate H1");
+  TryFormat("I 5", "Interstate 5");
+  TryFormat("I 35", "Interstate 35");
+  TryFormat("I 35E", "Interstate 35E");
+  TryFormat("I 35W", "Interstate 35W");
+  TryFormat("I 95 South", "Interstate 95 South");
+  TryFormat("I 270 Spur", "Interstate 2 70 Spur");
+  TryFormat("I 495 West", "Interstate 4 95 West");
+  TryFormat("I-695 West", "Interstate 6 95 West");
+  TryFormat("I-895", "Interstate 8 95");
+  TryFormat("i-205 East", "Interstate 2 o5 East");
+
+  TryFormat("US 1", "U.S. 1");
+  TryFormat("US 22", "U.S. 22");
+  TryFormat("US 220 North", "U.S. 2 20 North");
+  TryFormat("US-220 South", "U.S. 2 20 South");
+  TryFormat("US 202", "U.S. 2 o2");
+  TryFormat("Us 422 Business Alternate", "U.S. 4 22 Business Alternate");
+  TryFormat("Us-522", "U.S. 5 22");
+
+  TryFormat("AL 233", "Alabama 2 33");
+  TryFormat("AR 107", "Arkansas 1 o7");
+  TryFormat("PA 23", "Pennsylvania 23");
+  TryFormat("PA 283", "Pennsylvania 2 83");
+  TryFormat("PA 100", "Pennsylvania 1 hundred");
+  TryFormat("PA 1080", "Pennsylvania 10 80");
+  TryFormat("PA 4007", "Pennsylvania 40 o7");
+  TryFormat("SR 1021", "State Route 10 21");
+  TryFormat("SR-1021", "State Route 10 21");
+  TryFormat("Sr 1021", "State Route 10 21");
+  TryFormat("SR3032", "State Route 30 32");
+  TryFormat("CT 14A", "Connecticut 14A");
+
+  TryFormat("CR 539", "County Route 5 39");
+  TryFormat("CR-4003", "County Route 40 o3");
+
+  TryFormat("T609", "T6 o9");
+}
+
+}
+
+int main() {
+  test::suite suite("verbal_text_formatter_us");
+
+  // ProcessStatesTts
+  suite.test(TEST_CASE(TestProcessStatesTts));
+
+  // Format
+  suite.test(TEST_CASE(TestFormat));
+
+  return suite.tear_down();
+}

--- a/test/verbal_text_formatter_us_co.cc
+++ b/test/verbal_text_formatter_us_co.cc
@@ -139,6 +139,8 @@ void TestFormat() {
   TryFormat("Sr 1021", "State Route 10 21");
   TryFormat("SR3032", "State Route 30 32");
   TryFormat("CT 14A", "Connecticut 14A");
+  TryFormat("Co 7", "Colorado 7");
+  TryFormat("Co 200", "Colorado 2 hundred");
 
   TryFormat("CR 539", "County Route 5 39");
   TryFormat("CR-4003", "County Route 40 o3");

--- a/test/verbal_text_formatter_us_co.cc
+++ b/test/verbal_text_formatter_us_co.cc
@@ -151,7 +151,7 @@ void TestFormat() {
 }
 
 int main() {
-  test::suite suite("verbal_text_formatter_us");
+  test::suite suite("verbal_text_formatter_us_co");
 
   // ProcessStatesTts
   suite.test(TEST_CASE(TestProcessStatesTts));

--- a/test/verbal_text_formatter_us_tx.cc
+++ b/test/verbal_text_formatter_us_tx.cc
@@ -1,0 +1,142 @@
+#include <regex>
+
+#include "test.h"
+#include "valhalla/baldr/verbal_text_formatter.h"
+#include "valhalla/baldr/verbal_text_formatter_us.h"
+#include "valhalla/baldr/verbal_text_formatter_us_tx.h"
+
+using namespace std;
+using namespace valhalla::baldr;
+
+namespace {
+
+// Sub class to test protected methods
+class VerbalTextFormatterUsTxTest : public VerbalTextFormatterUsTx {
+ public:
+  VerbalTextFormatterUsTxTest(const std::string& country_code,
+                          const std::string& state_code)
+      : VerbalTextFormatterUsTx(country_code, state_code) {
+  }
+
+  std::string FormFmTts(const std::string& source) const {
+    return VerbalTextFormatterUsTx::FormFmTts(source);
+  }
+
+  std::string FormRmTts(const std::string& source) const {
+    return VerbalTextFormatterUsTx::FormRmTts(source);
+  }
+
+};
+
+void TryFormFmTts(string source, string expected) {
+  VerbalTextFormatterUsTxTest formatter_test("US", "TX");
+  string tts = formatter_test.FormFmTts(source);
+  if (tts != expected) {
+    throw std::runtime_error(
+        "Incorrect FormFmTts - EXPECTED: " + expected + "  |  FORMED: " + tts);
+  }
+}
+
+void TestFormFmTts() {
+  TryFormFmTts("FM1018", "Farm to Market Road 1018");
+  TryFormFmTts("FM 1018", "Farm to Market Road 1018");
+  TryFormFmTts("FM-1018", "Farm to Market Road 1018");
+  TryFormFmTts("F M 1018", "Farm to Market Road 1018");
+  TryFormFmTts("F-M 1018", "Farm to Market Road 1018");
+  TryFormFmTts("F-M-1018", "Farm to Market Road 1018");
+
+}
+
+void TryFormRmTts(string source, string expected) {
+  VerbalTextFormatterUsTxTest formatter_test("US", "TX");
+  string tts = formatter_test.FormRmTts(source);
+  if (tts != expected) {
+    throw std::runtime_error(
+        "Incorrect FormRmTts - EXPECTED: " + expected + "  |  FORMED: " + tts);
+  }
+}
+
+void TestFormRmTts() {
+  TryFormRmTts("RM1018", "Ranch to Market Road 1018");
+  TryFormRmTts("RM 1018", "Ranch to Market Road 1018");
+  TryFormRmTts("FM-1018", "Ranch to Market Road 1018");
+  TryFormRmTts("R M 1018", "Ranch to Market Road 1018");
+  TryFormRmTts("R-M 1018", "Ranch to Market Road 1018");
+  TryFormRmTts("R-M-1018", "Ranch to Market Road 1018");
+
+}
+
+void TryFormat(string source, string expected) {
+  VerbalTextFormatterUsTxTest formatter_test("US", "TX");
+  string tts = formatter_test.Format(source);
+  if (tts != expected) {
+    throw std::runtime_error(
+        "Incorrect Format - EXPECTED: " + expected + "  |  FORMED: " + tts);
+  }
+}
+
+void TestFormat() {
+  TryFormat("I H1", "Interstate H1");
+  TryFormat("I 5", "Interstate 5");
+  TryFormat("I 35", "Interstate 35");
+  TryFormat("I 35E", "Interstate 35E");
+  TryFormat("I 35W", "Interstate 35W");
+  TryFormat("I 95 South", "Interstate 95 South");
+  TryFormat("I 270 Spur", "Interstate 2 70 Spur");
+  TryFormat("I 495 West", "Interstate 4 95 West");
+  TryFormat("I-695 West", "Interstate 6 95 West");
+  TryFormat("I-895", "Interstate 8 95");
+  TryFormat("i-205 East", "Interstate 2 o5 East");
+
+  TryFormat("US 1", "U.S. 1");
+  TryFormat("US 22", "U.S. 22");
+  TryFormat("US 220 North", "U.S. 2 20 North");
+  TryFormat("US-220 South", "U.S. 2 20 South");
+  TryFormat("US 202", "U.S. 2 o2");
+  TryFormat("Us 422 Business Alternate", "U.S. 4 22 Business Alternate");
+  TryFormat("Us-522", "U.S. 5 22");
+
+  TryFormat("AL 233", "Alabama 2 33");
+  TryFormat("AR 107", "Arkansas 1 o7");
+  TryFormat("PA 23", "Pennsylvania 23");
+  TryFormat("PA 283", "Pennsylvania 2 83");
+  TryFormat("PA 100", "Pennsylvania 1 hundred");
+  TryFormat("PA 1080", "Pennsylvania 10 80");
+  TryFormat("PA 4007", "Pennsylvania 40 o7");
+  TryFormat("SR 1021", "State Route 10 21");
+  TryFormat("SR-1021", "State Route 10 21");
+  TryFormat("Sr 1021", "State Route 10 21");
+
+  TryFormat("CR 539", "County Route 5 39");
+  TryFormat("CR-4003", "County Route 40 o3");
+
+  TryFormat("FM1018", "Farm to Market Road 10 18");
+  TryFormat("FM 1018", "Farm to Market Road 10 18");
+  TryFormat("FM-1018", "Farm to Market Road 10 18");
+  TryFormat("F M 1018", "Farm to Market Road 10 18");
+  TryFormat("F-M 1018", "Farm to Market Road 10 18");
+  TryFormat("F-M-1018", "Farm to Market Road 10 18");
+
+  TryFormat("RM1018", "Ranch to Market Road 10 18");
+  TryFormat("RM 1018", "Ranch to Market Road 10 18");
+  TryFormat("RM-1018", "Ranch to Market Road 10 18");
+  TryFormat("R M 1018", "Ranch to Market Road 10 18");
+  TryFormat("R-M 1018", "Ranch to Market Road 10 18");
+  TryFormat("R-M-1018", "Ranch to Market Road 10 18");
+
+  TryFormat("T609", "T6 o9");
+}
+
+}
+
+int main() {
+  test::suite suite("verbal_text_formatter_us_tx");
+
+  // FormFmTts
+  suite.test(TEST_CASE(TestFormFmTts));
+
+  // Format
+  suite.test(TEST_CASE(TestFormat));
+
+  return suite.tear_down();
+}

--- a/valhalla/baldr/verbal_text_formatter_us.h
+++ b/valhalla/baldr/verbal_text_formatter_us.h
@@ -25,14 +25,16 @@ const std::string kUsHighwayOutPattern = "U.S. $3";
 const std::regex kLeadingOhRegex("( )(0)([1-9])");
 const std::string kLeadingOhOutPattern = "$1o$3";
 
-const std::array<std::pair<std::regex, std::string>, 3> kThousandFindReplace = {{
+const std::array<std::pair<std::regex, std::string>, 4> kThousandFindReplace = {{
     { std::regex("(^|\\D)([1-9]{1,2})(000$)"), "$1$2 thousand" },
+    { std::regex("(^|\\D)([1-9]{1,2})(000th)"), "$1$2 thousandth" },
     { std::regex("(^|\\D)([1-9]{1,2})(000)( |-)"), "$1$2 thousand " },
     { std::regex("(^|\\D)([1-9]{1,2})(000)(\\D)"), "$1$2 thousand $4" }
 }};
 
-const std::array<std::pair<std::regex, std::string>, 3> kHundredFindReplace = {{
+const std::array<std::pair<std::regex, std::string>, 4> kHundredFindReplace = {{
     { std::regex("(^|\\D)([1-9]{1,2})(00$)"), "$1$2 hundred" },
+    { std::regex("(^|\\D)([1-9]{1,2})(00th)"), "$1$2 hundredth" },
     { std::regex("(^|\\D)([1-9]{1,2})(00)( |-)"), "$1$2 hundred " },
     { std::regex("(^|\\D)([1-9]{1,2})(00)(\\D)"), "$1$2 hundred $4" }
 }};

--- a/valhalla/baldr/verbal_text_formatter_us.h
+++ b/valhalla/baldr/verbal_text_formatter_us.h
@@ -31,7 +31,7 @@ const std::string kHundredOutPattern = "$1$2 hundred$4";
 const std::regex kLeadingOhRegex("( )(0)([1-9])");
 const std::string kLeadingOhOutPattern = "$1o$3";
 
-const std::array<std::pair<std::regex, std::string>, 52> kStateRoutes = {{
+const std::array<std::pair<std::regex, std::string>, 53> kStateRoutes = {{
     { std::regex("(\\bSR)([ -])?(\\d{1,4})", std::regex_constants::icase), "State Route $3" },
     { std::regex("(\\bCA)([ -])(\\d{1,3})", std::regex_constants::icase), "California $3" },
     { std::regex("(\\bTX)([ -])(\\d{1,3})", std::regex_constants::icase), "Texas $3" },
@@ -51,6 +51,7 @@ const std::array<std::pair<std::regex, std::string>, 52> kStateRoutes = {{
     { std::regex("(\\bIN)([ -])(\\d{1,3})", std::regex_constants::icase), "Indiana $3" },
     { std::regex("(\\bTN)([ -])(\\d{1,3})", std::regex_constants::icase), "Tennessee $3" },
     { std::regex("(\\bMO)([ -])(\\d{1,3})", std::regex_constants::icase), "Missouri $3" },
+    { std::regex("(\\bMO)([ -])([[:alpha:]]{1,2})", std::regex_constants::icase), "Missouri $3" },
     { std::regex("(\\bMD)([ -])(\\d{1,3})", std::regex_constants::icase), "Maryland $3" },
     { std::regex("(\\bWI)([ -])(\\d{1,3})", std::regex_constants::icase), "Wisconsin $3" },
     { std::regex("(\\bMN)([ -])(\\d{1,3})", std::regex_constants::icase), "Minnesota $3" },

--- a/valhalla/baldr/verbal_text_formatter_us.h
+++ b/valhalla/baldr/verbal_text_formatter_us.h
@@ -51,7 +51,7 @@ const std::array<std::pair<std::regex, std::string>, 53> kStateRoutes = {{
     { std::regex("(\\bIN)([ -])(\\d{1,3})", std::regex_constants::icase), "Indiana $3" },
     { std::regex("(\\bTN)([ -])(\\d{1,3})", std::regex_constants::icase), "Tennessee $3" },
     { std::regex("(\\bMO)([ -])(\\d{1,3})", std::regex_constants::icase), "Missouri $3" },
-    { std::regex("(\\bMO)([ -])([[:alpha:]]{1,2})", std::regex_constants::icase), "Missouri $3" },
+    { std::regex("(\\bMO)([ -])([[:alpha:]]{1,2}\\b)", std::regex_constants::icase), "Missouri $3" },
     { std::regex("(\\bMD)([ -])(\\d{1,3})", std::regex_constants::icase), "Maryland $3" },
     { std::regex("(\\bWI)([ -])(\\d{1,3})", std::regex_constants::icase), "Wisconsin $3" },
     { std::regex("(\\bMN)([ -])(\\d{1,3})", std::regex_constants::icase), "Minnesota $3" },

--- a/valhalla/baldr/verbal_text_formatter_us.h
+++ b/valhalla/baldr/verbal_text_formatter_us.h
@@ -31,7 +31,7 @@ const std::string kHundredOutPattern = "$1$2 hundred$4";
 const std::regex kLeadingOhRegex("( )(0)([1-9])");
 const std::string kLeadingOhOutPattern = "$1o$3";
 
-const std::array<std::pair<std::regex, std::string>, 53> kStateRoutes = {{
+const std::array<std::pair<std::regex, std::string>, 52> kStateRoutes = {{
     { std::regex("(\\bSR)([ -])?(\\d{1,4})", std::regex_constants::icase), "State Route $3" },
     { std::regex("(\\bCA)([ -])(\\d{1,3})", std::regex_constants::icase), "California $3" },
     { std::regex("(\\bTX)([ -])(\\d{1,3})", std::regex_constants::icase), "Texas $3" },
@@ -55,7 +55,6 @@ const std::array<std::pair<std::regex, std::string>, 53> kStateRoutes = {{
     { std::regex("(\\bMD)([ -])(\\d{1,3})", std::regex_constants::icase), "Maryland $3" },
     { std::regex("(\\bWI)([ -])(\\d{1,3})", std::regex_constants::icase), "Wisconsin $3" },
     { std::regex("(\\bMN)([ -])(\\d{1,3})", std::regex_constants::icase), "Minnesota $3" },
-    { std::regex("(\\bCO)([ -])(\\d{1,3})", std::regex_constants::icase), "Colorado $3" },
     { std::regex("(\\bAL)([ -])(\\d{1,3})", std::regex_constants::icase), "Alabama $3" },
     { std::regex("(\\bSC)([ -])(\\d{1,3})", std::regex_constants::icase), "South Carolina $3" },
     { std::regex("(\\bLA)([ -])(\\d{1,4})", std::regex_constants::icase), "Louisiana $3" },
@@ -122,7 +121,7 @@ class VerbalTextFormatterUs : public VerbalTextFormatter {
 
   std::string FormUsHighwayTts(const std::string& source) const;
 
-  std::string ProcessStatesTts(const std::string& source) const;
+  virtual std::string ProcessStatesTts(const std::string& source) const;
 
   bool FormStateTts(const std::string& source, const std::regex& state_regex,
                     const std::string& state_output_pattern,

--- a/valhalla/baldr/verbal_text_formatter_us.h
+++ b/valhalla/baldr/verbal_text_formatter_us.h
@@ -22,14 +22,17 @@ const std::regex kUsHighwayRegex("(\\bUS)([ -])(\\d{1,3})",
                                  std::regex_constants::icase);
 const std::string kUsHighwayOutPattern = "U.S. $3";
 
+const std::regex kLeadingOhRegex("( )(0)([1-9])");
+const std::string kLeadingOhOutPattern = "$1o$3";
+
 const std::regex kThousandRegex("(^| )([1-9]{1,2})(000)($| )");
 const std::string kThousandOutPattern = "$1$2 thousand$4";
 
-const std::regex kHundredRegex("(^| )([1-9]{1,2})(00)($| )");
-const std::string kHundredOutPattern = "$1$2 hundred$4";
-
-const std::regex kLeadingOhRegex("( )(0)([1-9])");
-const std::string kLeadingOhOutPattern = "$1o$3";
+const std::array<std::pair<std::regex, std::string>, 3> kHundredFindReplace = {{
+    { std::regex("(^|\\D)([1-9]{1,2})(00$)"), "$1$2 hundred" },
+    { std::regex("(^|\\D)([1-9]{1,2})(00)( |-)"), "$1$2 hundred " },
+    { std::regex("(^|\\D)([1-9]{1,2})(00)(\\D)"), "$1$2 hundred $4" }
+}};
 
 const std::array<std::pair<std::regex, std::string>, 52> kStateRoutes = {{
     { std::regex("(\\bSR)([ -])?(\\d{1,4})", std::regex_constants::icase), "State Route $3" },
@@ -86,10 +89,14 @@ const std::array<std::pair<std::regex, std::string>, 52> kStateRoutes = {{
     { std::regex("(\\bWY)([ -])(\\d{1,3})", std::regex_constants::icase), "Wyoming $3" }
 }};
 
-// TODO - other special cases
-const std::array<std::pair<std::regex, std::string>, 2> kCountyRoutes = {{
-    { std::regex("(\\bCR)([ -])?(\\d{1,4})", std::regex_constants::icase), "County Route $3" },
-    { std::regex("(\\bC R)([ -])?(\\d{1,4})", std::regex_constants::icase), "County Route $3" },
+const std::array<std::pair<std::regex, std::string>, 7> kCountyRoutes = {{
+    { std::regex("(\\bCR)(\\d{1,4})([[:alpha:]]{1,2})?\\b", std::regex_constants::icase), "County Route $2$3" },
+    { std::regex("(\\bCR)([ -])([[:alpha:]]{1,2})?(\\d{1,4})([[:alpha:]]{1,2})?\\b", std::regex_constants::icase), "County Route $3$4$5" },
+    { std::regex("(\\bCR)([ -])([[:alpha:]]{1,2})\\b", std::regex_constants::icase), "County Route $3" },
+    { std::regex("(\\bC R)(\\d{1,4})([[:alpha:]]{1,2})?\\b", std::regex_constants::icase), "County Route $2$3" },
+    { std::regex("(\\bC R)([ -])([[:alpha:]]{1,2})?(\\d{1,4})([[:alpha:]]{1,2})?\\b", std::regex_constants::icase), "County Route $3$4$5" },
+    { std::regex("(\\bC R)([ -])([[:alpha:]]{1,2})\\b", std::regex_constants::icase), "County Route $3" },
+    { std::regex("(\\bCO)([ -])?(\\d{1,4})([[:alpha:]]{1,2})?\\b", std::regex_constants::icase), "County Road $3$4" }
 }};
 
 /**
@@ -135,7 +142,11 @@ class VerbalTextFormatterUs : public VerbalTextFormatter {
 
   std::string FormThousandTts(const std::string& source) const;
 
-  std::string FormHundredTts(const std::string& source) const;
+  std::string ProcessHundredTts(const std::string& source) const;
+
+  std::string FormHundredTts(const std::string& source,
+                             const std::regex& hundred_regex,
+                             const std::string& hundred_output_pattern) const;
 
   std::string FormLeadingOhTts(const std::string& source) const;
 };

--- a/valhalla/baldr/verbal_text_formatter_us.h
+++ b/valhalla/baldr/verbal_text_formatter_us.h
@@ -25,8 +25,11 @@ const std::string kUsHighwayOutPattern = "U.S. $3";
 const std::regex kLeadingOhRegex("( )(0)([1-9])");
 const std::string kLeadingOhOutPattern = "$1o$3";
 
-const std::regex kThousandRegex("(^| )([1-9]{1,2})(000)($| )");
-const std::string kThousandOutPattern = "$1$2 thousand$4";
+const std::array<std::pair<std::regex, std::string>, 3> kThousandFindReplace = {{
+    { std::regex("(^|\\D)([1-9]{1,2})(000$)"), "$1$2 thousand" },
+    { std::regex("(^|\\D)([1-9]{1,2})(000)( |-)"), "$1$2 thousand " },
+    { std::regex("(^|\\D)([1-9]{1,2})(000)(\\D)"), "$1$2 thousand $4" }
+}};
 
 const std::array<std::pair<std::regex, std::string>, 3> kHundredFindReplace = {{
     { std::regex("(^|\\D)([1-9]{1,2})(00$)"), "$1$2 hundred" },
@@ -140,7 +143,11 @@ class VerbalTextFormatterUs : public VerbalTextFormatter {
                     const std::string& county_output_pattern,
                     std::string& tts) const;
 
-  std::string FormThousandTts(const std::string& source) const;
+  std::string ProcessThousandTts(const std::string& source) const;
+
+  std::string FormThousandTts(const std::string& source,
+                              const std::regex& thousand_regex,
+                              const std::string& thousand_output_pattern) const;
 
   std::string ProcessHundredTts(const std::string& source) const;
 

--- a/valhalla/baldr/verbal_text_formatter_us.h
+++ b/valhalla/baldr/verbal_text_formatter_us.h
@@ -18,23 +18,23 @@ const std::regex kInterstateRegex("(\\bI)([ -])(H)?(\\d{1,3})",
                                   std::regex_constants::icase);
 const std::string kInterstateOutPattern = "Interstate $3$4";
 
-const std::regex kUsHighwayRegex("(\\bUS)([ -])(\\d{1,3})",
+const std::regex kUsHighwayRegex("(\\bUS)([ -])(Highway )?(\\d{1,3})",
                                  std::regex_constants::icase);
-const std::string kUsHighwayOutPattern = "U.S. $3";
+const std::string kUsHighwayOutPattern = "U.S. $3$4";
 
 const std::regex kLeadingOhRegex("( )(0)([1-9])");
 const std::string kLeadingOhOutPattern = "$1o$3";
 
 const std::array<std::pair<std::regex, std::string>, 4> kThousandFindReplace = {{
     { std::regex("(^|\\D)([1-9]{1,2})(000$)"), "$1$2 thousand" },
-    { std::regex("(^|\\D)([1-9]{1,2})(000th)"), "$1$2 thousandth" },
+    { std::regex("(^|\\D)([1-9]{1,2})(000th)", std::regex_constants::icase), "$1$2 thousandth" },
     { std::regex("(^|\\D)([1-9]{1,2})(000)( |-)"), "$1$2 thousand " },
     { std::regex("(^|\\D)([1-9]{1,2})(000)(\\D)"), "$1$2 thousand $4" }
 }};
 
 const std::array<std::pair<std::regex, std::string>, 4> kHundredFindReplace = {{
     { std::regex("(^|\\D)([1-9]{1,2})(00$)"), "$1$2 hundred" },
-    { std::regex("(^|\\D)([1-9]{1,2})(00th)"), "$1$2 hundredth" },
+    { std::regex("(^|\\D)([1-9]{1,2})(00th)", std::regex_constants::icase), "$1$2 hundredth" },
     { std::regex("(^|\\D)([1-9]{1,2})(00)( |-)"), "$1$2 hundred " },
     { std::regex("(^|\\D)([1-9]{1,2})(00)(\\D)"), "$1$2 hundred $4" }
 }};

--- a/valhalla/baldr/verbal_text_formatter_us.h
+++ b/valhalla/baldr/verbal_text_formatter_us.h
@@ -39,8 +39,9 @@ const std::array<std::pair<std::regex, std::string>, 4> kHundredFindReplace = {{
     { std::regex("(^|\\D)([1-9]{1,2})(00)(\\D)"), "$1$2 hundred $4" }
 }};
 
-const std::array<std::pair<std::regex, std::string>, 52> kStateRoutes = {{
+const std::array<std::pair<std::regex, std::string>, 53> kStateRoutes = {{
     { std::regex("(\\bSR)([ -])?(\\d{1,4})", std::regex_constants::icase), "State Route $3" },
+    { std::regex("(\\bSH)([ -])?(\\d{1,4})", std::regex_constants::icase), "State Highway $3" },
     { std::regex("(\\bCA)([ -])(\\d{1,3})", std::regex_constants::icase), "California $3" },
     { std::regex("(\\bTX)([ -])(\\d{1,3})", std::regex_constants::icase), "Texas $3" },
     { std::regex("(\\bFL)([ -])(A)?(\\d{1,3})", std::regex_constants::icase), "Florida $3$4" },

--- a/valhalla/baldr/verbal_text_formatter_us_co.h
+++ b/valhalla/baldr/verbal_text_formatter_us_co.h
@@ -1,0 +1,40 @@
+#ifndef VALHALLA_BALDR_VERBAL_TEXT_FORMATTER_US_CO_H_
+#define VALHALLA_BALDR_VERBAL_TEXT_FORMATTER_US_CO_H_
+
+#include <valhalla/baldr/verbal_text_formatter.h>
+
+#include <regex>
+#include <string>
+#include <array>
+#include <utility>
+
+namespace valhalla {
+namespace baldr {
+
+
+const std::regex kColoradoRegex("(\\bCO)([ -])(\\d{1,3})",
+                                  std::regex_constants::icase);
+const std::string kColoradoOutPattern = "Colorado $3";
+
+
+/**
+ * The Colorado, US specific verbal text formatter class that prepares strings
+ * for use with a text-to-speech engine.
+ */
+class VerbalTextFormatterUsCo : public VerbalTextFormatterUs {
+ public:
+  VerbalTextFormatterUsCo(const std::string& country_code,
+                        const std::string& state_code);
+
+  ~VerbalTextFormatterUsCo();
+
+ protected:
+
+  std::string ProcessStatesTts(const std::string& source) const override;
+
+};
+
+}
+}
+
+#endif  // VALHALLA_BALDR_VERBAL_TEXT_FORMATTER_US_CO_H_

--- a/valhalla/baldr/verbal_text_formatter_us_tx.h
+++ b/valhalla/baldr/verbal_text_formatter_us_tx.h
@@ -1,0 +1,54 @@
+#ifndef VALHALLA_BALDR_VERBAL_TEXT_FORMATTER_US_TX_H_
+#define VALHALLA_BALDR_VERBAL_TEXT_FORMATTER_US_TX_H_
+
+#include <valhalla/baldr/verbal_text_formatter.h>
+
+#include <regex>
+#include <string>
+#include <array>
+#include <utility>
+
+namespace valhalla {
+namespace baldr {
+
+// Farm to Market
+const std::regex kFmRegex("(\\bF[ -]?M)([ -])?(\\d{1,4})",
+                          std::regex_constants::icase);
+const std::string kFmOutPattern = "Farm to Market Road $3";
+
+// Ranch to Market
+const std::regex kRmRegex("(\\bR[ -]?M)([ -])?(\\d{1,4})",
+                          std::regex_constants::icase);
+const std::string kRmOutPattern = "Ranch to Market Road $3";
+
+/**
+ * The Texas, US specific verbal text formatter class that prepares strings
+ * for use with a text-to-speech engine.
+ */
+class VerbalTextFormatterUsTx : public VerbalTextFormatterUs {
+ public:
+  VerbalTextFormatterUsTx(const std::string& country_code,
+                          const std::string& state_code);
+
+  ~VerbalTextFormatterUsTx();
+
+  /**
+   * Returns a Texas, US text-to-speech formatted string based on the specified text.
+   *
+   * @param  text  the source string to transform.
+   * @return a Texas, US text-to-speech formatted string based on the specified text.
+   */
+  std::string Format(const std::string& text) const override;
+
+ protected:
+
+  std::string FormFmTts(const std::string& source) const;
+
+  std::string FormRmTts(const std::string& source) const;
+
+};
+
+}
+}
+
+#endif  // VALHALLA_BALDR_VERBAL_TEXT_FORMATTER_US_TX_H_


### PR DESCRIPTION
BEFORE (incorrectly calling out Colorado)
Turn left onto Colorado 2 o2.
AFTER
Turn left onto County Road 2 o2.

BEFORE
Turn left onto FM 25 81.
AFTER
Turn left onto Farm to Market Road 25 81.

BEFORE
Turn left to stay on RM 3 37.
AFTER
Turn left to stay on Ranch to Market Road 3 37.

BEFORE
Turn left onto 2nd Street, MO JJ.
AFTER
Turn left onto 2nd Street, Missouri JJ.

BEFORE
Continue on SH 4 70.
AFTER
Continue on State Highway 4 70.