### PR TITLE
add timezone data to a header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ srtmtest
 *.lo
 .libs/
 libvalhalla_baldr.la
+date_time_zonespec.csv
+valhalla/baldr/date_time_zonespec.h
 
 # tests
 test-suite.log

--- a/Makefile.am
+++ b/Makefile.am
@@ -35,6 +35,13 @@ clean-gcno:
 clean-local: clean-coverage clean-gcno
 endif
 
+#timezone info from boost
+valhalla/baldr/date_time_zonespec.h:
+	-wget -q https://raw.githubusercontent.com/boostorg/date_time/master/data/date_time_zonespec.csv
+	-xxd -i date_time_zonespec.csv > valhalla/baldr/date_time_zonespec.h
+CLEANFILES = date_time_zonespec.csv valhalla/baldr/date_time_zonespec.h
+
+
 # libvalhalla-baldr compilation etc
 lib_LTLIBRARIES = libvalhalla_baldr.la
 nobase_include_HEADERS = \
@@ -73,7 +80,8 @@ nobase_include_HEADERS = \
 	valhalla/baldr/verbal_text_formatter_us.h \
 	valhalla/baldr/verbal_text_formatter_us_co.h \
 	valhalla/baldr/verbal_text_formatter_us_tx.h \
-	valhalla/baldr/verbal_text_formatter_factory.h
+	valhalla/baldr/verbal_text_formatter_factory.h \
+        valhalla/baldr/date_time_zonespec.h
 libvalhalla_baldr_la_SOURCES = \
         src/baldr/admin.cc \
 	src/baldr/admininfo.cc \
@@ -111,6 +119,7 @@ libvalhalla_baldr_la_SOURCES = \
 	src/baldr/verbal_text_formatter_factory.cc
 libvalhalla_baldr_la_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_CPPFLAGS) @BOOST_CPPFLAGS@
 libvalhalla_baldr_la_LIBADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) @BOOST_LDFLAGS@ $(BOOST_SYSTEM_LIB) $(BOOST_FILESYSTEM_LIB) $(BOOST_THREAD_LIB) $(BOOST_SERIALIZATION_LIB) $(BOOST_DATE_TIME_LIB)
+#test_util_DEPENDENCIES = 
 
 #distributed executables
 bin_PROGRAMS = srtmtest

--- a/Makefile.am
+++ b/Makefile.am
@@ -119,7 +119,6 @@ libvalhalla_baldr_la_SOURCES = \
 	src/baldr/verbal_text_formatter_factory.cc
 libvalhalla_baldr_la_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_CPPFLAGS) @BOOST_CPPFLAGS@
 libvalhalla_baldr_la_LIBADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) @BOOST_LDFLAGS@ $(BOOST_SYSTEM_LIB) $(BOOST_FILESYSTEM_LIB) $(BOOST_THREAD_LIB) $(BOOST_SERIALIZATION_LIB) $(BOOST_DATE_TIME_LIB)
-#test_util_DEPENDENCIES = 
 
 #distributed executables
 bin_PROGRAMS = srtmtest


### PR DESCRIPTION
this will create a header `valhalla/baldr/date_time_zonespec.h` from the data found at https://raw.githubusercontent.com/boostorg/date_time/master/data/date_time_zonespec.csv

the header will look like 

    unsigned char date_time_zonespec_csv[] = {
      0x22, 0x49, 0x44, 0x22, 0x2c, 0x22, 0x53, 0x54, 0x44, 0x20, 0x41, 0x42,
      0x42, 0x52, 0x22, 0x2c, 0x22, 0x53, 0x54, 0x44, 0x20, 0x4e, 0x41, 0x4d,
    ...
      0x22, 0x2c, 0x22, 0x22, 0x2c, 0x22, 0x22, 0x2c, 0x22, 0x22, 0x2c, 0x22,
      0x2b, 0x30, 0x30, 0x3a, 0x30, 0x30, 0x3a, 0x30, 0x30, 0x22, 0x0a
    };
    unsigned int date_time_zonespec_csv_len = 35855;


then wherever @gknisely needs to load this data all he must do is loop over this binary data, write it to file, and then send that temp file to boost to load up the timezone stuff. this makes it so we dont have to guess where it is on the system.

i suggest we call wahtever boost function with this tempfile and store the resulting object in a static initializer (singleton) in an anonymous namespace and have whatever namespace level function just return results from that.