### PR TITLE
added flag to check if the date that was inputed is before the tile_creation date.

### DIFF
--- a/src/baldr/graphtile.cc
+++ b/src/baldr/graphtile.cc
@@ -396,7 +396,7 @@ std::vector<SignInfo> GraphTile::GetSigns(const uint32_t idx) const {
 // time (seconds from midnight).
 const TransitDeparture* GraphTile::GetNextDeparture(const uint32_t lineid,
                  const uint32_t current_time, const uint32_t day,
-                 const uint32_t dow) const {
+                 const uint32_t dow, bool date_before_tile) const {
   uint32_t count = header_->departurecount();
   if (count == 0) {
     return nullptr;
@@ -442,7 +442,7 @@ const TransitDeparture* GraphTile::GetNextDeparture(const uint32_t lineid,
       // If within 60 days of tile creation use the days mask else fallback
       // to the day of week mask
       const TransitDeparture& dep = departures_[mid];
-      if (day <= dep.end_day()) {
+      if (!date_before_tile && day <= dep.end_day()) {
         // Check days bit
         if ((dep.days() & (1ULL << day))) {
           return &dep;

--- a/valhalla/baldr/graphtile.h
+++ b/valhalla/baldr/graphtile.h
@@ -173,17 +173,20 @@ class GraphTile {
   /**
    * Get the next departure given the directed edge Id and the current
    * time (seconds from midnight). TODO - what if crosses midnight?
-   * @param   edgeid  Directed edge Id.
-   * @param   current_time  Current time (seconds from midnight).
-   * @param   day     Days since the tile creation date.
-   * @param   dow     Day of week (see graphconstants.h)
+   * @param   edgeid            Directed edge Id.
+   * @param   current_time      Current time (seconds from midnight).
+   * @param   day               Days since the tile creation date.
+   * @param   dow               Day of week (see graphconstants.h)
+   * @param   date_before_tile  Is the date that was inputed before
+   *                            the tile creation date?
    * @return  Returns a pointer to the transit departure information.
    *          Returns nullptr if no departures are found.
    */
   const TransitDeparture* GetNextDeparture(const uint32_t edgeid,
                                            const uint32_t current_time,
                                            const uint32_t day,
-                                           const uint32_t dow) const;
+                                           const uint32_t dow,
+                                           bool  date_before_tile) const;
 
   /**
    * Get the departure given the directed edge Id and tripid


### PR DESCRIPTION
We need this because date can be less than tile_creation date and in MMcosting we were doing the calculation of day = date - tile_creation_date_;  And day is unsigned.  

Thor updates coming as well.