### PR TITLE
Remove the shared variable NO_TILE which causes problems in concurrent

### DIFF
--- a/src/baldr/graphreader.cc
+++ b/src/baldr/graphreader.cc
@@ -13,7 +13,6 @@ using namespace valhalla::baldr;
 namespace {
   constexpr size_t DEFAULT_MAX_CACHE_SIZE = 1073741824; //1 gig
   constexpr size_t AVERAGE_TILE_SIZE = 2097152; //2 megs
-  const GraphTile* NO_TILE = nullptr;
 }
 
 namespace valhalla {
@@ -97,6 +96,7 @@ bool GraphReader::OverCommitted() const {
 
 // Convenience method to get an opposing directed edge graph Id.
 GraphId GraphReader::GetOpposingEdgeId(const GraphId& edgeid) {
+  const GraphTile* NO_TILE = nullptr;
   return GetOpposingEdgeId(edgeid, NO_TILE);
 }
 GraphId GraphReader::GetOpposingEdgeId(const GraphId& edgeid, const GraphTile*& tile) {
@@ -116,6 +116,7 @@ GraphId GraphReader::GetOpposingEdgeId(const GraphId& edgeid, const GraphTile*& 
 
 // Convenience method to get an opposing directed edge.
 const DirectedEdge* GraphReader::GetOpposingEdge(const GraphId& edgeid) {
+  const GraphTile* NO_TILE = nullptr;
   return GetOpposingEdge(edgeid, NO_TILE);
 }
 const DirectedEdge* GraphReader::GetOpposingEdge(const GraphId& edgeid, const GraphTile*& tile) {


### PR DESCRIPTION
Since `NO_TILE` is shared globally, it's possible to be changed multiple times during you call `GraphId GraphReader::GetOpposingEdgeId(const GraphId&, const GraphTile*&)` in concurrent and result in out-of-bound issue.

Here is the script to reproduce/verify the issue https://gist.github.com/ptpt/5e07d21bf68f32de7b16