### PR TITLE
nullptr_t is in the std namespace.

### DIFF
--- a/src/baldr/graphid.cc
+++ b/src/baldr/graphid.cc
@@ -72,7 +72,7 @@ json::Value GraphId::json() const {
       {"tile_id", static_cast<uint64_t>(fields.tileid)},
       {"id", static_cast<uint64_t>(fields.id)},
     });
-  return static_cast<nullptr_t>(nullptr);
+  return static_cast<std::nullptr_t>(nullptr);
 }
 
 // Post increments the id.


### PR DESCRIPTION
Fixes a compile error on OpenBSD:

    src/baldr/graphid.cc: In member function 'valhalla::baldr::json::Value valhalla::baldr::GraphId::json() const':
    src/baldr/graphid.cc:75:22: error: 'nullptr_t' does not name a type
       return static_cast<nullptr_t>(nullptr);
                      ^
