### PR TITLE
Validate tile header density value.

### DIFF
--- a/src/baldr/graphtileheader.cc
+++ b/src/baldr/graphtileheader.cc
@@ -56,7 +56,7 @@ uint32_t GraphTileHeader::density() const {
 
 // Set the relative road density within this tile.
 void GraphTileHeader::set_density(const uint32_t density) {
-  density_ = density;
+  density_ = (density <= kMaxDensity) ? density : kMaxDensity;
 }
 
 // Get the relative quality of name assignment for this tile.

--- a/valhalla/baldr/graphconstants.h
+++ b/valhalla/baldr/graphconstants.h
@@ -31,6 +31,9 @@ enum class Traversability {
   kBoth = 3         // Edge is traversable in both directions
 };
 
+// Maximum relative density at a node or within a tile
+constexpr uint32_t kMaxDensity = 15;
+
 // Maximum speed. This impacts the effectiveness of A* for driving routes
 // so it should be set as low as is reasonable. Speeds above this in OSM are
 // clamped to this maximum value.

--- a/valhalla/baldr/nodeinfo.h
+++ b/valhalla/baldr/nodeinfo.h
@@ -20,7 +20,6 @@ constexpr uint32_t kMaxAdminsPerTile    = 63;       // Maximum Admins per tile
 constexpr uint32_t kMaxTimeZonesPerTile = 511;      // Maximum TimeZones index
 constexpr uint32_t kMaxLocalEdgeIndex   = 7;        // Max. index of edges on
                                                     // local level
-constexpr uint32_t kMaxDensity = 15;              // Max. relative node density
 
 // Heading shrink factor to reduce max heading of 359 to 255
 constexpr float kHeadingShrinkFactor = (255.f/359.f);


### PR DESCRIPTION
Move kMaxDensity to graphconstants.h so it can be used for both node and tile density.