### PR TITLE
Also set reverseaccess to all

### DIFF
--- a/src/baldr/directededge.cc
+++ b/src/baldr/directededge.cc
@@ -404,8 +404,10 @@ void DirectedEdge::set_forwardaccess(const uint32_t modes) {
 }
 
 // Set all forward access modes to true (used for transition edges)
+// Also sets reverse access so opposing edge matches.
 void DirectedEdge::set_all_forward_access() {
   forwardaccess_ = kAllAccess;
+  reverseaccess_ = kAllAccess;
 }
 
 // Get the access modes in the reverse direction (bit field).


### PR DESCRIPTION
(this is used for transition edges and this change makes it so access can be checked on opposing edges to make sure they match (forward against reverse on opposing edge and vice-versa).