### PR TITLE
schedule fix

### DIFF
--- a/src/baldr/datetime.cc
+++ b/src/baldr/datetime.cc
@@ -89,6 +89,11 @@ uint64_t get_service_days(boost::gregorian::date& start_date, boost::gregorian::
   else if (tile_header_date > end_date) //reject.
     return 0;
 
+  // if our start date is in the future then we must start at the tile header date
+  // since we always use the tile header date as our start date.
+  if (start_date > tile_header_date)
+    start_date = tile_header_date;
+
   // only support 60 days out.  (59 days and include the end_date = 60)
   boost::gregorian::date enddate = start_date + boost::gregorian::days(59);
 
@@ -96,10 +101,6 @@ uint64_t get_service_days(boost::gregorian::date& start_date, boost::gregorian::
     end_date = enddate;
 
   uint32_t days = 0;
-  //if our start date is in the future then we must start at that date.
-  if (start_date > tile_header_date)
-    days = days_from_pivot_date(start_date) - tile_date;
-
   boost::gregorian::day_iterator itr(tile_header_date + boost::gregorian::days(days));
 
   uint32_t x = days;


### PR DESCRIPTION
Schedule bug.

We were using the start_date set by the transit builder (service_start_date) and not the tile header date.  We should always start from the tile header date and go out 60 days.  

This issue caused the schedule to be off which in turn cause invalid transit routes. 

Old:

2016/02/24 17:18:59.466341 [NARRATIVE] ----------------------------------------------
**2016/02/24 17:18:59.466347 [NARRATIVE] 13: Enter the Babylon station. | 0.0 mi**
2016/02/24 17:18:59.466353 [NARRATIVE]    VERBAL_PRE: Enter the Babylon station.
2016/02/24 17:18:59.466358 [NARRATIVE]    VERBAL_POST: Continue for 100 feet.
2016/02/24 17:18:59.466362 [NARRATIVE] ----------------------------------------------
2016/02/24 17:18:59.466367 [NARRATIVE]    Depart: 12:00 PM from Babylon.
2016/02/24 17:18:59.466372 [NARRATIVE]    VERBAL_DEPART: Depart at 12:00 PM from Babylon.
**2016/02/24 17:18:59.466379 [NARRATIVE] 14: Take the Babylon toward Penn Station. (1 stop) | 13.9 mi**
2016/02/24 17:18:59.466385 [NARRATIVE]    VERBAL_PRE: Take the Babylon toward Penn Station.
2016/02/24 17:18:59.466390 [NARRATIVE]    VERBAL_POST: Travel 1 stop.
2016/02/24 17:18:59.466395 [NARRATIVE]    Arrive: 12:21 PM at Freeport.
2016/02/24 17:18:59.466400 [NARRATIVE]    VERBAL_ARRIVE: Arrive at 12:21 PM at Freeport.
2016/02/24 17:18:59.466405 [NARRATIVE] ----------------------------------------------
2016/02/24 17:18:59.466409 [NARRATIVE]    Depart: 12:27 PM from Freeport.
2016/02/24 17:18:59.466414 [NARRATIVE]    VERBAL_DEPART: Depart at 12:27 PM from Freeport.
**2016/02/24 17:18:59.466421 [NARRATIVE] 15: Transfer to take the Babylon toward Penn Station. (3 stops) | 12.3 mi**
2016/02/24 17:18:59.466427 [NARRATIVE]    VERBAL_PRE: Transfer to take the Babylon toward Penn Station.
2016/02/24 17:18:59.466432 [NARRATIVE]    VERBAL_POST: Travel 3 stops.
2016/02/24 17:18:59.466437 [NARRATIVE]    Arrive: 12:50 PM at Jamaica.
2016/02/24 17:18:59.466442 [NARRATIVE]    VERBAL_ARRIVE: Arrive at 12:50 PM at Jamaica.
2016/02/24 17:18:59.466447 [NARRATIVE] ----------------------------------------------
2016/02/24 17:18:59.466453 [NARRATIVE] 16: Exit the Jamaica station. | 0.0 mi
2016/02/24 17:18:59.466458 [NARRATIVE]    VERBAL_PRE: Exit the Jamaica station.
2016/02/24 17:18:59.466463 [NARRATIVE]    VERBAL_POST: Continue for 200 feet.
2016/02/24 17:18:59.466467 [NARRATIVE] ----------------------------------------------

New:

2016/02/24 17:37:57.039706 [NARRATIVE] ----------------------------------------------
**2016/02/24 17:37:57.039713 [NARRATIVE] 13: Enter the Babylon station. | 0.0 mi**
2016/02/24 17:37:57.039718 [NARRATIVE]    VERBAL_PRE: Enter the Babylon station.
2016/02/24 17:37:57.039723 [NARRATIVE]    VERBAL_POST: Continue for 100 feet.
2016/02/24 17:37:57.039727 [NARRATIVE] ----------------------------------------------
2016/02/24 17:37:57.039732 [NARRATIVE]    Depart: 12:00 PM from Babylon.
2016/02/24 17:37:57.039737 [NARRATIVE]    VERBAL_DEPART: Depart at 12:00 PM from Babylon.
**2016/02/24 17:37:57.039744 [NARRATIVE] 14: Take the Babylon toward Penn Station. (3 stops) | 36.4 mi**
2016/02/24 17:37:57.039750 [NARRATIVE]    VERBAL_PRE: Take the Babylon toward Penn Station.
2016/02/24 17:37:57.039755 [NARRATIVE]    VERBAL_POST: Travel 3 stops.
2016/02/24 17:37:57.039760 [NARRATIVE]    Arrive: 1:05 PM at Penn Station.
2016/02/24 17:37:57.039765 [NARRATIVE]    VERBAL_ARRIVE: Arrive at 1:05 PM at Penn Station.
2016/02/24 17:37:57.039770 [NARRATIVE] ----------------------------------------------
**2016/02/24 17:37:57.039776 [NARRATIVE] 15: Exit the Penn Station station. | 0.2 mi**
2016/02/24 17:37:57.039782 [NARRATIVE]    VERBAL_PRE: Exit the Penn Station station.
2016/02/24 17:37:57.039787 [NARRATIVE]    VERBAL_POST: Continue for 2 tenths of a mile.
2016/02/24 17:37:57.039791 [NARRATIVE] ----------------------------------------------
