### PR TITLE
GetOpposingEdgeId - return invalid GraphId for transit lines

### DIFF
--- a/src/baldr/graphreader.cc
+++ b/src/baldr/graphreader.cc
@@ -102,6 +102,13 @@ GraphId GraphReader::GetOpposingEdgeId(const GraphId& edgeid) {
 GraphId GraphReader::GetOpposingEdgeId(const GraphId& edgeid, const GraphTile*& tile) {
   tile = GetGraphTile(edgeid);
   const auto* directededge = tile->directededge(edgeid);
+
+  // For now return an invalid Id if this is a transit edge
+  if (directededge->IsTransitLine()) {
+    return {};
+  }
+
+  // Get the opposing edge, if edge leaves the tile get the end node's tile
   GraphId id = directededge->endnode();
   if (directededge->leaves_tile()) {
     // Get tile at the end node


### PR DESCRIPTION
Return an invalid GraphId when getting the opposing edge of a transit line. These do not have proper opposing edges assigned yet.