### PR TITLE
TransitDeparture Rework

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -73,6 +73,7 @@ nobase_include_HEADERS = \
 	valhalla/baldr/streetnames_us.h \
 	valhalla/baldr/transitdeparture.h \
 	valhalla/baldr/transitroute.h \
+	valhalla/baldr/transitschedule.h \
 	valhalla/baldr/transitstop.h \
 	valhalla/baldr/transittransfer.h \
 	valhalla/baldr/verbal_text_formatter.h \
@@ -106,6 +107,7 @@ libvalhalla_baldr_la_SOURCES = \
 	src/baldr/streetnames_us.cc \
 	src/baldr/transitdeparture.cc \
 	src/baldr/transitroute.cc \
+	src/baldr/transitschedule.cc \
 	src/baldr/transitstop.cc \
 	src/baldr/transittransfer.cc \
 	src/baldr/verbal_text_formatter.cc \

--- a/src/baldr/graphtileheader.cc
+++ b/src/baldr/graphtileheader.cc
@@ -126,6 +126,11 @@ uint32_t GraphTileHeader::departurecount() const {
 
 // Sets the number of transit departures in this tile.
 void GraphTileHeader::set_departurecount(const uint32_t departures) {
+  // Check against limit
+  if (departures > kMaxTransitDepartures) {
+    throw std::runtime_error(
+        "Exceeding maximum number of transit departures per tile");
+  }
   departurecount_ = departures;
 }
 
@@ -136,6 +141,11 @@ uint32_t GraphTileHeader::stopcount() const {
 
 // Sets the number of transit stops in this tile.
 void GraphTileHeader::set_stopcount(const uint32_t stops) {
+  // Check against limit
+  if (stops >= kMaxTransitStops) {
+    throw std::runtime_error(
+        "Exceeding maximum number of transit stops per tile");
+  }
   stopcount_ = stops;
 }
 
@@ -146,17 +156,27 @@ uint32_t GraphTileHeader::routecount() const {
 
 // Sets the number of transit routes in this tile.
 void GraphTileHeader::set_routecount(const uint32_t routes) {
+  // Check against limit
+  if (routes >= kMaxTransitRoutes) {
+    throw std::runtime_error(
+        "Exceeding maximum number of transit routes per tile");
+  }
   routecount_ = routes;
 }
 
-// Gets the number of transit transfers in this tile.
-uint32_t GraphTileHeader::transfercount() const {
-  return transfercount_;
+// Gets the number of transit schedules in this tile.
+uint32_t GraphTileHeader::schedulecount() const {
+  return schedulecount_;
 }
 
-// Sets the number of transit transfers in this tile.
-void GraphTileHeader::set_transfercount(const uint32_t transfers) {
-  transfercount_ = transfers;
+// Sets the number of transit schedules in this tile.
+void GraphTileHeader::set_schedulecount(const uint32_t schedules) {
+  // Check against limit
+  if (schedules >= kMaxTransitSchedules) {
+    throw std::runtime_error(
+        "Exceeding maximum number of transit schedule entries per tile");
+  }
+  schedulecount_ = schedules;
 }
 
 // Gets the number of access restrictions in this tile.

--- a/src/baldr/transitschedule.cc
+++ b/src/baldr/transitschedule.cc
@@ -1,0 +1,65 @@
+#include "baldr/transitschedule.h"
+
+namespace valhalla {
+namespace baldr {
+
+/**
+ * Constructor with arguments
+ * @param  days      Bit field indicating the days (from tile creation
+ *                   date) that a schedule entry is valid.
+ * @param  dow       Days of week (beyond the end day) that the schedule
+ *                   entry is valid.
+ * @param  end_day   End day (from tile creation date) for this schedule
+ *                  entry.
+ */
+TransitSchedule::TransitSchedule(const uint64_t days, const uint32_t dow,
+                const uint32_t end_day)
+    : days_(days),
+      days_of_week_(dow),
+      end_day_(end_day) {
+  }
+
+// Gets the days that this departure is valid.  Supports 64 days from tile
+// creation date.
+uint64_t TransitSchedule::days() const {
+  return days_;
+}
+
+// Gets the days of the week for this departure.
+uint32_t TransitSchedule::days_of_week() const {
+  return days_of_week_;
+}
+
+// Get the end day for this scheduled departure.
+uint32_t TransitSchedule::end_day() const {
+  return end_day_;
+}
+
+// Checks if the schedule entry is valid for the specified day and
+// day of week. If within end_day_ days of tile creation use the days mask
+// else fall back to the day of week mask.
+bool TransitSchedule::IsValid(const uint32_t day, const uint32_t dow,
+             bool date_before_tile) const {
+  if (!date_before_tile && day <= end_day_) {
+    // Check days bit
+    return ((days_ & (1ULL << day)));
+  } else {
+    return ((days_of_week_ & dow) > 0);
+  }
+}
+
+// For sorting so we can make unique list of schedule records per tile
+ bool TransitSchedule::operator < (const TransitSchedule& other) const {
+   if (days_ == other.days_) {
+     if (days_of_week_ == other.days_of_week_) {
+       return end_day_ < other.end_day_;
+     } else {
+       return days_of_week_ < other.days_of_week_;
+     }
+   } else {
+     return days_ < other.days_;
+   }
+ }
+
+}
+}

--- a/valhalla/baldr/graphconstants.h
+++ b/valhalla/baldr/graphconstants.h
@@ -18,6 +18,16 @@ constexpr uint8_t kBusAccess        = 64;
 constexpr uint8_t kHOVAccess        = 128;
 constexpr uint8_t kAllAccess        = 255;
 
+// Maximum number of transit records per tile
+constexpr uint32_t kMaxTransitDepartures    = 16777215;
+constexpr uint32_t kMaxTransitStops         = 65535;
+constexpr uint32_t kMaxTransitRoutes        = 4095;
+constexpr uint32_t kMaxTransitSchedules     = 4095;
+constexpr uint32_t kMaxTransitBlockId       = 1048575;
+constexpr uint32_t kMaxTransitLineId        = 1048576;
+constexpr uint32_t kMaxTransitDepartureTime = 131071;
+constexpr uint32_t kMaxTransitElapsedTime   = 32767;
+
 // Payment constants. Bit constants.
 constexpr uint8_t kCoins  = 1; // Coins
 constexpr uint8_t kNotes  = 2; // Bills
@@ -115,6 +125,9 @@ constexpr uint32_t kMaxStopImpact = 7;
 // Maximum grade and curvature factors.
 constexpr uint32_t kMaxGradeFactor = 15;
 constexpr uint32_t kMaxCurvatureFactor = 15;
+
+// Maximum added time along shortcuts to approximate transition costs
+constexpr uint32_t kMaxAddedTime = 255;
 
 // Node types.
 enum class NodeType : uint8_t {

--- a/valhalla/baldr/graphtile.h
+++ b/valhalla/baldr/graphtile.h
@@ -9,7 +9,7 @@
 #include <valhalla/baldr/transitdeparture.h>
 #include <valhalla/baldr/transitroute.h>
 #include <valhalla/baldr/transitstop.h>
-#include <valhalla/baldr/transittransfer.h>
+#include <valhalla/baldr/transitschedule.h>
 #include <valhalla/baldr/sign.h>
 #include <valhalla/baldr/edgeinfo.h>
 #include <valhalla/baldr/admininfo.h>
@@ -213,25 +213,12 @@ class GraphTile {
   const TransitRoute* GetTransitRoute(const uint32_t idx) const;
 
   /**
-   * Get a pointer to the first transfer record given the stop Id and
-   * compute the number of transfer records for the stop.
-   * @param   stopid  Stop Id.
-   * @return  Returns a pair with a pointer to the initial transfer record
-   *          and a count of transfer records from the given stop Id.
+   * Get the transit schedule given its schedule index.
+   * @param   idx     Schedule index within the tile.
+   * @return  Returns a pointer to the transit schedule information. Returns
+   *          nullptr if the schedule is not found.
    */
-  std::pair<TransitTransfer*, uint32_t> GetTransfers(
-      const uint32_t stopid) const;
-
-  /**
-   * Get a pointer to the transfer record given the from stop Id and
-   * the to stop id.
-   * @param   from_stopid  From stop Id.
-   * @param   to_stopid    To stop Id.
-   * @return  Returns a pointer to the transfer record between the 2 stops.
-   *          Returns nullptr if no transfer record exists.
-   */
-  TransitTransfer* GetTransfer(const uint32_t from_stopid,
-                               const uint32_t to_stopid) const;
+  const TransitSchedule* GetTransitSchedule(const uint32_t idx) const;
 
   /**
    * Convenience method to get the access restrictions for an edge given the
@@ -283,14 +270,14 @@ class GraphTile {
   // sorted by departure time)
   TransitDeparture* departures_;
 
-  // Transit stops (indexed by stop Id - unique)
+  // Transit stops (indexed by stop index within the tile)
   TransitStop* transit_stops_;
 
-  // Transit route (indexed by route Id - unique)
+  // Transit route (indexed by route index within the tile)
   TransitRoute* transit_routes_;
 
-  // Transit transfers, 1 or more per index (indexed by from stop Id)
-  TransitTransfer* transit_transfers_;
+  // Transit schedules (index by schedule index within the tile)
+  TransitSchedule* transit_schedules_;
 
   // Access restrictions, 1 or more per edge id
   AccessRestriction* access_restrictions_;

--- a/valhalla/baldr/graphtileheader.h
+++ b/valhalla/baldr/graphtileheader.h
@@ -185,16 +185,16 @@ class GraphTileHeader {
   void set_routecount(const uint32_t routes);
 
   /**
-   * Gets the number of transit transfers in this tile.
-   * @return  Returns the number of transit transfers.
+   * Gets the number of transit schedules in this tile.
+   * @return  Returns the number of transit schedules.
    */
-  uint32_t transfercount() const;
+  uint32_t schedulecount() const;
 
   /**
-   * Sets the number of transit transfers in this tile.
-   * @param  transfers   The number of transit transfers.
+   * Sets the number of transit schedules in this tile.
+   * @param  schedules   The number of transit schedules.
    */
-  void set_transfercount(const uint32_t transfers);
+  void set_schedulecount(const uint32_t schedules);
 
   /**
    * Gets the number of access restrictions in this tile.
@@ -295,11 +295,11 @@ class GraphTileHeader {
   uint64_t exit_quality_  : 4;
   uint64_t spare1_        : 48;
 
-  // Number of transit departure records
+  // Number of transit records
   uint64_t departurecount_ : 24;
   uint64_t stopcount_      : 16;
   uint64_t routecount_     : 12;
-  uint64_t transfercount_  : 12;
+  uint64_t schedulecount_  : 12;
 
   // Date the tile was created. Days since pivot date.
   uint32_t date_created_;

--- a/valhalla/baldr/transitdeparture.h
+++ b/valhalla/baldr/transitdeparture.h
@@ -13,21 +13,23 @@ namespace baldr {
  */
 class TransitDeparture {
  public:
-  // Construct with arguments
+  /**
+   * Constructor with arguments.
+   * @param  lineid   Unique line Id within the tile
+   * @param  tripid   Unique trip Id (spans tiles)
+   * @param  routeid  Route index within the tile.
+   * @param  blockid  Block Id.
+   * @param  headsign_offset  Offset to headsign within the text/name table.
+   * @param  departure_time   Departure time (seconds from midnight)
+   * @param  elapsed_time     Elapsed time to next stop
+   * @param  schedule_index   Index into schedule validity table for this tile
+   */
   TransitDeparture(const uint32_t lineid, const uint32_t tripid,
                    const uint32_t routeid, const uint32_t blockid,
                    const uint32_t headsign_offset,
                    const uint32_t departure_time,
                    const uint32_t elapsed_time,
-                   const uint32_t end_day,
-                   const uint32_t days_of_week,
-                   const uint64_t days);
-
-  /**
-   * Gets the days that this departure is valid.  60 days
-   * @return  Returns the days
-   */
-  uint64_t days() const;
+                   const uint32_t schedule_index);
 
   /**
    * Get the line Id - for lookup of all departures along this edge. Each
@@ -43,13 +45,13 @@ class TransitDeparture {
   uint32_t tripid() const;
 
   /**
-   * Get the route Id (internal) for this departure.
+   * Get the route index for this departure.
    * @return  Returns the internal route Id.
    */
   uint32_t routeid() const;
 
   /**
-   * Get the block Id oof this trip.
+   * Get the block Id of this trip.
    * @return  Returns the block Id.
    */
   uint32_t blockid() const;
@@ -73,16 +75,10 @@ class TransitDeparture {
   uint32_t elapsed_time() const;
 
   /**
-   * Get the end day for this scheduled departure.
-   * @return  Returns the end day (what is our end day in the days_).
+   * Get the schedule validity index.
+   * @return  Returns the index into the transit schedules.
    */
-  uint32_t end_day() const;
-
-  /**
-   * Gets the days of the week for this departure.
-   * @return  Returns the days of the week (dow mask)
-   */
-  uint32_t days_of_week() const;
+  uint32_t schedule_index() const;
 
   /**
    * operator < - for sorting. Sort by line Id and departure time.
@@ -93,27 +89,21 @@ class TransitDeparture {
   bool operator < (const TransitDeparture& other) const;
 
  protected:
-  uint64_t days_;                // Days this departure is active relative to
-                                 // the tile's creation date. Stores bit field
-                                 // with 1's meaning the departure applies
-                                 // to the day.
-  uint32_t lineid_;              // Line Id - lookup departures by unique line
-                                 // Id (which indicates a unique departure /
-                                 // arrival stop pair.
-  uint32_t tripid_;              // TripId (internal).
-  uint32_t headsign_offset_;     // Headsign offset into the names/text list.
+  uint32_t lineid_          : 20; // Line Id - lookup departures by unique line
+                                  // Id (which indicates a unique departure /
+                                  // arrival stop pair.
+  uint32_t routeid_         : 12; // Route index.
 
-  uint32_t routeid_      :26;    // Route Id (internal).
-  uint32_t end_day_      :6;     // End day (what is our end day in the days_).
+  uint32_t tripid_;               // TripId (internal).
+  uint32_t headsign_offset_;      // Headsign offset into the names/text list.
 
-  uint32_t blockid_      : 25;   // Block Id
-  uint32_t days_of_week_ : 7;    // Days of the week
+  uint32_t blockid_         : 20;  // Block Id
+  uint32_t schedule_index_  : 12; // Schedule validity index
 
-  uint32_t departure_time_ : 17; // Departure time (seconds from midnight)
-                                 // (86400 secs per day)
-  uint32_t elapsed_time_   : 15; // Time (secs) until arrival at next stop
 
-  // TODO - fare info, frequencies
+  uint32_t departure_time_  : 17; // Departure time (seconds from midnight)
+                                  // (86400 secs per day)
+  uint32_t elapsed_time_    : 15; // Time (secs) until arrival at next stop
 };
 
 }

--- a/valhalla/baldr/transitschedule.h
+++ b/valhalla/baldr/transitschedule.h
@@ -1,0 +1,74 @@
+#ifndef VALHALLA_BALDR_TRANSITSCHEDULE_H_
+#define VALHALLA_BALDR_TRANSITSCHEDULE_H_
+
+#include <valhalla/baldr/graphconstants.h>
+
+namespace valhalla {
+namespace baldr {
+
+/**
+ * Transit schedule validity information for departures from a stop.
+ * Stores which days a departure at a given time is valid. A list of
+ * unique schedule validity entries within a tile is kept in this record.
+ */
+class TransitSchedule {
+ public:
+  /**
+   * Constructor with arguments
+   * @param  days     Bit field indicating the days (from tile creation
+   *                  date) that a schedule entry is valid.
+   * @param  dow      Days of week (beyond the end day) that the schedule
+   *                  entry is valid.
+   * @param  end_day  End day (from tile creation date) for this schedule
+   *                  entry.
+   */
+  TransitSchedule(const uint64_t days, const uint32_t dow,
+                  const uint32_t end_day);
+
+  /**
+   * Gets the days that this departure is valid. Supports 64 days from tile
+   * creation date.
+   * @return  Returns the days
+   */
+  uint64_t days() const;
+
+  /**
+   * Gets the days of the week for this departure.
+   * @return  Returns the days of the week (bit mask)
+   */
+  uint32_t days_of_week() const;
+
+  /**
+   * Get the end day for this scheduled departure (number of days
+   * from tile creation date that is represented in days_).
+   * @return  Returns the end day.
+   */
+  uint32_t end_day() const;
+
+  /**
+   * Checks if the schedule entry is valid for the specified day and
+   * day of week. If within end_day_ days of tile creation use the days mask
+   * else fall back to the day of week bit mask.
+   * @param  day  Days since tile creation.
+   * @param  dow  Day of week.
+   * @param  date_before_tile  Is the date prior to the tile creation date.
+   * @return Returns true if the departure is valid, false otherwise.
+   */
+  bool IsValid(const uint32_t day, const uint32_t dow,
+               bool date_before_tile) const;
+
+  // For sorting so we can make unique list of schedule records per tile
+  bool operator < (const TransitSchedule& other) const;
+
+ protected:
+  uint64_t days_;          // Days this departure is active relative to the
+                           // tile's creation date. Stores bit field with 1's
+                           // meaning the departure applies to the day.
+  uint32_t days_of_week_;  // Days of the week.
+  uint32_t end_day_;       // End day (what is our end day in the days_).
+};
+
+}
+}
+
+#endif  // VALHALLA_BALDR_TRANSITSCHEDULE_H_


### PR DESCRIPTION
Add a structure to store unique schedule validity periods. 
Replace TransitTransfer (unused) with the new TransitSchedule structure within tiles.
Separate transit schedule information from transit departures and index into the new TransitSchedule records. 
Compress TransitDeparture to get down to 20 bytes per departure (was 32).
Check max. values and throw exceptions when exceeded.