### PR TITLE
Send in tile directory to GetTileId (rather than TileHierarchy).

### DIFF
--- a/src/baldr/connectivity_map.cc
+++ b/src/baldr/connectivity_map.cc
@@ -95,7 +95,7 @@ namespace valhalla {
           if(boost::filesystem::exists(root_dir) && boost::filesystem::is_directory(root_dir)) {
             for (boost::filesystem::recursive_directory_iterator i(root_dir), end; i != end; ++i) {
               if (!boost::filesystem::is_directory(i->path())) {
-                GraphId id = GraphTile::GetTileId(i->path().string(), tile_hierarchy);
+                GraphId id = GraphTile::GetTileId(i->path().string(), tile_hierarchy.tile_dir());
                 level_colors.insert({id.tileid(), 0});
               }
             }

--- a/src/baldr/graphtile.cc
+++ b/src/baldr/graphtile.cc
@@ -204,12 +204,12 @@ std::string GraphTile::FileSuffix(const GraphId& graphid, const TileHierarchy& h
 }
 
 // Get the tile Id given the full path to the file.
-GraphId GraphTile::GetTileId(const std::string& fname, const TileHierarchy& hierarchy) {
+GraphId GraphTile::GetTileId(const std::string& fname, const std::string& tile_dir) {
   //strip off the unuseful part
-  auto pos = fname.find(hierarchy.tile_dir());
+  auto pos = fname.find(tile_dir);
   if(pos == std::string::npos)
     throw std::runtime_error("File name for tile does not match hierarchy root dir");
-  auto name = fname.substr(pos + hierarchy.tile_dir().size());
+  auto name = fname.substr(pos + tile_dir.size());
   boost::algorithm::trim_if(name, boost::is_any_of("/.gph"));
 
   //split on slash

--- a/valhalla/baldr/graphtile.h
+++ b/valhalla/baldr/graphtile.h
@@ -56,11 +56,11 @@ class GraphTile {
 
   /**
    * Get the tile Id given the full path to the file.
-   * @param  fname  Filename with complete path.
-   * @param  hierarchy the tile hierarchy this tile is under
+   * @param  fname    Filename with complete path.
+   * @param  tile_dir Base tile directory.
    * @return  Returns the tile Id.
    */
-  static GraphId GetTileId(const std::string& fname, const TileHierarchy& hierarchy);
+  static GraphId GetTileId(const std::string& fname, const std::string& tile_dir);
 
   /**
    * Get the bounding box of this graph tile.


### PR DESCRIPTION
 Should allow this to be used by transit tiles.