### PR TITLE
connectivity map as polygons instead of point clouds

### DIFF
--- a/src/baldr/connectivity_map.cc
+++ b/src/baldr/connectivity_map.cc
@@ -144,7 +144,7 @@ namespace {
     auto tile = start_tile;
     auto side = start_side;
     polygon_t polygon{{}};
-    std::list<PointLL> outer = polygon.front();
+    std::list<PointLL>& outer = polygon.front();
     std::array<std::unordered_set<uint32_t>, 4> used;
     do {
       //add this edges geometry

--- a/src/baldr/connectivity_map.cc
+++ b/src/baldr/connectivity_map.cc
@@ -56,7 +56,7 @@ namespace {
     return json::map({
       {"fill", color},
       {"stroke", std::string("white")},
-      {"stroke-width", std::string("1")},
+      {"stroke-width", static_cast<uint64_t>(1)},
       {"fill-opacity", json::fp_t{0.8, 1}},
       {"id", id},
     });

--- a/src/baldr/connectivity_map.cc
+++ b/src/baldr/connectivity_map.cc
@@ -237,7 +237,7 @@ namespace valhalla {
       }
 
       //record the arity of each region so we can put the biggest ones first
-      auto comp = [](const size_t& a, const size_t& b){return a < b;};
+      auto comp = [](const size_t& a, const size_t& b){return a > b;};
       std::multimap<size_t, size_t, decltype(comp)> arities(comp);
       for(const auto& region : regions)
         arities.emplace(region.second.size(), region.first);

--- a/src/baldr/connectivity_map.cc
+++ b/src/baldr/connectivity_map.cc
@@ -5,6 +5,10 @@
 #include <valhalla/midgard/pointll.h>
 #include <boost/filesystem.hpp>
 #include <list>
+#include <iomanip>
+#include <random>
+#include <sstream>
+#include <unordered_set>
 
 using namespace valhalla::baldr;
 using namespace valhalla::midgard;
@@ -46,41 +50,126 @@ namespace {
      }
    */
 
-  json::MapPtr to_properties(const size_t color) {
+  json::MapPtr to_properties(uint64_t id, const std::string& color) {
     return json::map({
-      {std::string("color"), static_cast<uint64_t>(color)}
+      {"fillColor", color},
+      {"id", id},
     });
   }
 
-  json::MapPtr to_geometry(const std::list<PointLL>& tiles) {
-    auto multipoint = json::array({});
-    for(const auto& tile : tiles)
-      multipoint->emplace_back(json::array({json::fp_t{tile.first, 6}, json::fp_t{tile.second, 6}}));
+  using ring_t = std::list<PointLL>;
+  using polygon_t = std::list<ring_t>;
+  json::MapPtr to_geometry(const polygon_t& polygon) {
+    auto coords = json::array({});
+    bool outer = true;
+    for(const auto& ring : polygon) {
+      auto ring_coords = json::array({});
+      for(const auto& coord : ring) {
+        if(outer)
+          ring_coords->emplace_back(json::array({json::fp_t{coord.first, 6}, json::fp_t{coord.second, 6}}));
+        else
+          ring_coords->emplace_front(json::array({json::fp_t{coord.first, 6}, json::fp_t{coord.second, 6}}));
+      }
+      coords->emplace_back(ring_coords);
+      outer = false;
+    }
     return json::map({
-      {std::string("type"), std::string("MultiPoint")},
-      {std::string("coordinates"), multipoint}
+      {"type", std::string("Polygon")},
+      {"coordinates", json::array({ coords })}
     });
   }
 
-  json::MapPtr to_feature(const std::pair<size_t, std::list<PointLL> >& region) {
+  json::MapPtr to_feature(const std::pair<size_t, polygon_t>& boundary, const std::string& color) {
     return json::map({
-      {std::string("type"), std::string("Feature")},
-      {std::string("geometry"), to_geometry(region.second)},
-      {std::string("properties"), to_properties(region.first)}
+      {"type", std::string("Feature")},
+      {"geometry", to_geometry(boundary.second)},
+      {"properties", to_properties(boundary.first, color)}
     });
   }
 
   template <class T>
-  std::string to_feature_collection(const std::unordered_map<size_t, std::list<PointLL> >& regions, const std::multimap<size_t, size_t, T>& arities) {
+  std::string to_feature_collection(const std::unordered_map<size_t, polygon_t>& boundaries, const std::multimap<size_t, size_t, T>& arities) {
+    std::default_random_engine generator;
+    std::uniform_int_distribution<int> distribution(64,192);
     auto features = json::array({});
-    for(const auto& arity : arities)
-      features->emplace_back(to_feature(*regions.find(arity.second)));
+    for(const auto& arity : arities) {
+      std::stringstream hex;
+      hex << "#" << std::hex << distribution(generator);
+      hex << std::hex << distribution(generator);
+      hex << std::hex << distribution(generator);
+      features->emplace_back(to_feature(*boundaries.find(arity.second), hex.str()));
+    }
     std::stringstream ss;
     ss << *json::map({
-      {std::string("type"), std::string("FeatureCollection")},
-      {std::string("features"), features}
+      {"type", std::string("FeatureCollection")},
+      {"features", features}
     });
     return ss.str();
+  }
+
+  polygon_t to_boundary(const std::pair<size_t, std::unordered_set<uint32_t> >& region, const Tiles<PointLL>& tiles) {
+    //get the neighbor tile giving -1 if no neighbor
+    auto neighbor = [&tiles](uint32_t tile, int side) {
+      auto rc = tiles.GetRowColumn(tile);
+      switch(side) {
+        case 0: return rc.first == 0 ? -1 : tile - 1;
+        case 1: return rc.second == 0 ? -1 : tile - tiles.ncolumns();
+        case 2: return rc.first == tiles.ncolumns() - 1 ? -1 : tile + 1;
+        case 3: return rc.second == tiles.nrows() - 1 ? -1 : tile + tiles.ncolumns();
+      }
+    };
+    //is the edge of the given tile a boundary of another region
+    auto is_boundary = [&region, &tiles, &neighbor](uint32_t tile, int side) {
+      return region.second.find(neighbor(tile, side)) == region.second.cend();
+    };
+    //get the beginning coord of the counter clockwise winding given edge of the given tile
+    auto get_coord = [&tiles](uint32_t tile, int side) {
+      auto box = tiles.TileBounds(tile);
+      switch(side) {
+        case 0: return PointLL(box.minx(), box.maxy());
+        case 1: return box.minpt();
+        case 2: return PointLL(box.maxx(), box.miny());
+        case 3: return box.maxpt();
+      }
+    };
+
+    //the smallest numbered tile has a left edge on the outer ring of the polygon
+    auto start_tile = *region.second.cbegin();
+    int start_side = 0;
+    for(auto tile : region.second)
+      if(tile < start_tile)
+        start_tile = tile;
+
+    //walk the outer until you get back to the first tile edge you found
+    auto tile = start_tile;
+    auto side = start_side;
+    polygon_t polygon{{}};
+    std::list<PointLL> outer = polygon.front();
+    std::array<std::unordered_set<uint32_t>, 4> used;
+    do {
+      //add this edges geometry
+      outer.push_back(get_coord(tile, side));
+      used[side].emplace(tile);
+      //we need to move to another tile if the next edge of this one isnt a boundary
+      if(!is_boundary(tile, (side + 1) % 4)) {
+        tile = neighbor(tile, (side + 1) % 4);
+        if(!is_boundary(tile, side)) {
+          tile = neighbor(tile, side);
+          side = (side + 3) % 4;
+        }
+      }//the next edge of this tile is a boundary so move to that
+      else
+        side = (side + 1) % 4;
+    } while(tile != start_tile || side != start_side);
+
+    //build the inners while there should still be some
+    //while(region.second.size() * 4 > used[0].size() + used[1].size() + used[2].size() + used[3].size()) {
+      //find an unmarked inner side
+
+    //}
+
+    //give it back
+    return polygon;
   }
 }
 
@@ -129,37 +218,39 @@ namespace valhalla {
     }
 
     std::string connectivity_map_t::to_geojson(const uint32_t hierarchy_level) const {
-      // Get the color level (throw exception if we don't have it)
+      //bail if we dont have the level
+      auto bbox = tile_hierarchy.levels().find(
+        hierarchy_level == transit_level ? transit_level - 1 : hierarchy_level);
       auto level = colors.find(hierarchy_level);
-      if (level == colors.cend()) {
-        throw std::runtime_error("No connectivity map for level");
-      }
-
-      // Get the tile bounding box (special case for transit tiles).
-      uint32_t tile_level = (hierarchy_level == transit_level) ? transit_level - 1 : hierarchy_level;
-      auto bbox = tile_hierarchy.levels().find(tile_level);
-      if (bbox == tile_hierarchy.levels().cend())
+      if(bbox == tile_hierarchy.levels().cend() || level == colors.cend())
         throw std::runtime_error("hierarchy level not found");
 
       //make a region map (inverse mapping of color to lists of tiles)
       //could cache this but shouldnt need to call it much
-      std::unordered_map<size_t, std::list<PointLL> > regions;
+      std::unordered_map<size_t, std::unordered_set<uint32_t> > regions;
       for(const auto& tile : level->second) {
         auto region = regions.find(tile.second);
         if(region == regions.end())
-          regions.emplace(tile.second, std::list<PointLL>{bbox->second.tiles.Center(tile.first)});
+          regions.emplace(tile.second, std::unordered_set<uint32_t>{tile.first});
         else
-          region->second.push_back(bbox->second.tiles.Center(tile.first));
+          region->second.emplace(tile.first);
       }
 
       //record the arity of each region so we can put the biggest ones first
-      auto comp = [](const size_t& a, const size_t& b){return a > b;};
+      auto comp = [](const size_t& a, const size_t& b){return a < b;};
       std::multimap<size_t, size_t, decltype(comp)> arities(comp);
       for(const auto& region : regions)
         arities.emplace(region.second.size(), region.first);
 
+      //get the boundary of each region
+      std::unordered_map<size_t, polygon_t> boundaries;
+      for(const auto& arity : arities) {
+        auto& region = *regions.find(arity.second);
+        boundaries.emplace(arity.second, to_boundary(region, bbox->second.tiles));
+      }
+
       //turn it into geojson
-      return to_feature_collection<decltype(comp)>(regions, arities);
+      return to_feature_collection<decltype(comp)>(boundaries, arities);
     }
 
     std::vector<size_t> connectivity_map_t::to_image(const uint32_t hierarchy_level) const {

--- a/valhalla/baldr/connectivity_map.h
+++ b/valhalla/baldr/connectivity_map.h
@@ -44,6 +44,7 @@ namespace valhalla {
 
      private:
       uint32_t transit_level;
+      //this is a map(tile_level, map(tile_id, tile_color))
       std::unordered_map<uint32_t, std::unordered_map<uint32_t, size_t> > colors;
       TileHierarchy tile_hierarchy;
     };

--- a/valhalla/baldr/json.h
+++ b/valhalla/baldr/json.h
@@ -8,7 +8,7 @@
 #include <cinttypes>
 #include <cstddef>
 #include <unordered_map>
-#include <vector>
+#include <list>
 #include <sstream>
 #include <iomanip>
 
@@ -41,10 +41,10 @@ class Jmap : public std::unordered_map<std::string, Value> {
 };
 
 //the array value type in json
-class Jarray : public std::vector<Value> {
+class Jarray : public std::list<Value> {
  public:
   //just specialize vector
-  using std::vector<Value>::vector;
+  using std::list<Value>::list;
  protected:
   //and be able to spit out text
   friend std::ostream& operator<<(std::ostream&, const Jarray&);


### PR DESCRIPTION
before the geojson output was points and was not great for efficiency nor display. now its polygons which is far easier to use.

caveat, i havent yet implemented the inner rings of the polygons and therefore you may see two different connectivity regions (specifically smaller ones inside of big ones) that touch eachother. This is because one of them is inside of a missing inner ring of another one. i'll get that in another pr.

ive also styled the geojson so that it displays nicely on geojson.io. once these are up on s3 we can use geojson.ios api to display the latest ones directly from a github.io page. i'll hack that together at some point..