### PR TITLE
refactor for fuzzy connectivity map and loki islands multiple results

### DIFF
--- a/src/baldr/connectivity_map.cc
+++ b/src/baldr/connectivity_map.cc
@@ -249,6 +249,29 @@ namespace valhalla {
       return color->second;
     }
 
+    std::unordered_set<size_t> connectivity_map_t::get_colors(uint32_t hierarchy_level,
+      const baldr::PathLocation& location, float radius) const {
+
+      std::unordered_set<size_t> result;
+      auto level = colors.find(hierarchy_level);
+      if(level == colors.cend())
+        return result;
+      const auto& tiles = tile_hierarchy.levels().find(hierarchy_level)->second.tiles;
+      for(const auto& edge : location.edges) {
+        //TODO: generate more ids by intersecting this circle with the tiles object
+        //take the edge.projected and subtract radius in the x and y dimensions
+        //convert that into a tileid and get its col,row tile coords that will start the for loop
+        //add radius in the x and y to edge.projected to get the ending tile col,row for the for loop
+        //then while iterating create a tile for each tile col,row pair, get its aabb2 and call
+        //aabb2::intersects(edge.projected, radius), if it returns true, get the color as below
+        auto id = tiles.TileId(edge.projected);
+        auto color = level->second.find(id);
+        if(color != level->second.cend())
+          result.emplace(color->second);
+      }
+      return result;
+    }
+
     std::string connectivity_map_t::to_geojson(const uint32_t hierarchy_level) const {
       //bail if we dont have the level
       auto bbox = tile_hierarchy.levels().find(

--- a/src/baldr/graphreader.cc
+++ b/src/baldr/graphreader.cc
@@ -37,16 +37,6 @@ bool GraphReader::DoesTileExist(const TileHierarchy& tile_hierarchy, const Graph
   return stat(file_location.c_str(), &buffer) == 0;
 }
 
-bool GraphReader::AreConnected(const GraphId& first, const GraphId& second) const {
-  //singleton is efficient here but does mean we cant reconfigure the tiles on the fly
-  static const connectivity_map_t connectivity_map(this->tile_hierarchy_);
-
-  //both must be the same color but also neither must be 0
-  auto first_color = connectivity_map.get_color(first.Tile_Base());
-  auto second_color = connectivity_map.get_color(second.Tile_Base());
-  return first_color == second_color && first_color != 0;
-}
-
 // Get a pointer to a graph tile object given a GraphId.
 const GraphTile* GraphReader::GetGraphTile(const GraphId& graphid) {
   //TODO: clear the cache automatically once we become overcommitted by a certain amount

--- a/src/baldr/pathlocation.cc
+++ b/src/baldr/pathlocation.cc
@@ -4,59 +4,26 @@
 namespace valhalla{
 namespace baldr{
 
-  PathLocation::PathEdge::PathEdge(const GraphId& id, const float dist, const SideOfStreet sos): id(id), dist(dist), sos(sos) {
+  PathLocation::PathEdge::PathEdge(const GraphId& id, const float dist,
+    const midgard::PointLL& projected, const SideOfStreet sos): id(id), dist(dist), projected(projected), sos(sos) {
+  }
+  bool PathLocation::PathEdge::begin_node() const {
+    return dist == 0.f;
+  }
+  bool PathLocation::PathEdge::end_node() const {
+    return dist == 1.f;
   }
 
   PathLocation::PathLocation(const Location& location):Location(location) {
-    node_ = false;
-    edges_.reserve(16);
-  }
-
-  bool PathLocation::IsNode() const {
-    return node_;
-  }
-
-  void PathLocation::CorrelateEdge(const PathEdge& edge) {
-    //whether or not we are only correlated to nodes in the graph
-    node_ = (node_ || edges_.size() == 0) && (1 == edge.dist || edge.dist == 0);
-    //add the edge
-    edges_.push_back(edge);
-  }
-
-  void PathLocation::CorrelateEdge(PathEdge&& edge) {
-    //whether or not we are only correlated to nodes in the graph
-    node_ = (node_ || edges_.size() == 0) && (1 == edge.dist || edge.dist == 0);
-    //add the edge
-    edges_.emplace_back(edge);
-  }
-
-  const std::vector<PathLocation::PathEdge>& PathLocation::edges() const {
-    return edges_;
-  }
-
-  const midgard::PointLL& PathLocation::vertex() const{
-    return vertex_;
-  }
-
-  bool PathLocation::IsCorrelated() const {
-    return vertex_.IsValid() && edges_.size() /*&& correlation_quality_ <= 1.f*/;
-  }
-
-  void PathLocation::CorrelateVertex(const midgard::PointLL& vertex) {
-    vertex_ = vertex;
-  }
-
-  void PathLocation::ClearEdges() {
-    edges_.clear();
+    edges.reserve(16);
   }
 
   bool PathLocation::operator==(const PathLocation& other) const {
-    if(node_ != other.node_ || !vertex_.ApproximatelyEqual(other.vertex_))
-      return false;
-    for(const auto& edge : edges_) {
+    for(const auto& edge : edges) {
       bool found = false;
-      for(const auto& other_edge : other.edges_) {
-        if(edge.id == other_edge.id && edge.sos == other_edge.sos && midgard::equal<float>(edge.dist, other_edge.dist)){
+      for(const auto& other_edge : other.edges) {
+        if(edge.id == other_edge.id && edge.sos == other_edge.sos && midgard::equal<float>(edge.dist, other_edge.dist) &&
+            edge.projected.ApproximatelyEqual(other_edge.projected)){
           found = true;
           break;
         }
@@ -70,17 +37,16 @@ namespace baldr{
   boost::property_tree::ptree PathLocation::ToPtree(size_t index) const {
     boost::property_tree::ptree correlated;
     auto& array = correlated.put_child("edges", boost::property_tree::ptree());
-    for(const auto& edge : edges_) {
+    for(const auto& edge : edges) {
       boost::property_tree::ptree e;
       e.put("id", edge.id.value);
       e.put("dist", edge.dist);
+      auto& vtx = e.put_child("projected", boost::property_tree::ptree());
+      vtx.put("lon", edge.projected.first);
+      vtx.put("lat", edge.projected.second);
       e.put("sos", edge.sos);
       array.push_back(std::make_pair("", e));
     }
-    correlated.put("is_node", IsNode());
-    auto& vtx = correlated.put_child("vertex", boost::property_tree::ptree());
-    vtx.put("lon", vertex_.lng());
-    vtx.put("lat", vertex_.lat());
     correlated.put("location_index", index);
     return correlated;
   }
@@ -88,11 +54,11 @@ namespace baldr{
   PathLocation PathLocation::FromPtree(const std::vector<Location>& locations, const boost::property_tree::ptree& path_location){
     auto index = path_location.get<size_t>("location_index");
     PathLocation p(locations[index]);
-    p.node_ = path_location.get<bool>("is_node");
-    p.vertex_.set_x(path_location.get<float>("vertex.lon"));
-    p.vertex_.set_y(path_location.get<float>("vertex.lat"));
-    for(const auto& edge : path_location.get_child("edges"))
-      p.edges_.emplace_back(GraphId(edge.second.get<uint64_t>("id")), edge.second.get<float>("dist"), static_cast<SideOfStreet>(edge.second.get<int>("sos")));
+    for(const auto& edge : path_location.get_child("edges")) {
+      p.edges.emplace_back(GraphId(edge.second.get<uint64_t>("id")), edge.second.get<float>("dist"),
+        midgard::PointLL(edge.second.get<float>("projected.lon"), edge.second.get<float>("projected.lat")),
+        static_cast<SideOfStreet>(edge.second.get<int>("sos")));
+    }
     return p;
   }
 

--- a/test/graphreader.cc
+++ b/test/graphreader.cc
@@ -1,6 +1,7 @@
 #include "test.h"
 
 #include "baldr/graphreader.h"
+#include "baldr/connectivity_map.h"
 
 #include <fcntl.h>
 #include <boost/filesystem.hpp>
@@ -65,13 +66,9 @@ void touch_tile(const uint32_t tile_id, const TileHierarchy& tile_hierarchy) {
 
 void TestConnectivityMap() {
   //get the hierarchy to create some tiles
-  std::stringstream json; json << "\
-  {\
-    \"tile_dir\": \"test/tiles\"\
-  }";
   boost::property_tree::ptree pt;
-  boost::property_tree::read_json(json, pt);
-  TileHierarchy th("test/tiles");
+  pt.put("tile_dir", "test/gphrdr_test");
+  TileHierarchy th("test/gphrdr_test");
   const auto& level = th.levels().find(2)->second;
   boost::filesystem::remove_all(th.tile_dir());
 
@@ -107,20 +104,20 @@ void TestConnectivityMap() {
   touch_tile(d1, th);
 
   //check that it looks right
-  GraphReader reader(pt);
-  if(!reader.AreConnected({a0, 2, 0}, {a1, 2, 0}))
+  connectivity_map_t conn(th);
+  if(conn.get_color({a0, 2, 0}) != conn.get_color({a1, 2, 0}))
     throw std::runtime_error("a's should be connected");
-  if(!reader.AreConnected({a0, 2, 0}, {a2, 2, 0}))
+  if(conn.get_color({a0, 2, 0}) != conn.get_color({a2, 2, 0}))
     throw std::runtime_error("a's should be connected");
-  if(!reader.AreConnected({a1, 2, 0}, {a2, 2, 0}))
+  if(conn.get_color({a1, 2, 0}) != conn.get_color({a2, 2, 0}))
     throw std::runtime_error("a's should be connected");
-  if(!reader.AreConnected({d0, 2, 0}, {d1, 2, 0}))
+  if(conn.get_color({d0, 2, 0}) != conn.get_color({d1, 2, 0}))
     throw std::runtime_error("d's should be connected");
-  if(reader.AreConnected({c0, 2, 0}, {a1, 2, 0}))
+  if(conn.get_color({c0, 2, 0}) == conn.get_color({a1, 2, 0}))
     throw std::runtime_error("c is disjoint");
-  if(reader.AreConnected({b0, 2, 0}, {a0, 2, 0}))
+  if(conn.get_color({b0, 2, 0}) == conn.get_color({a0, 2, 0}))
     throw std::runtime_error("b is disjoint");
-  if(reader.AreConnected({a2, 2, 0}, {d0, 2, 0}))
+  if(conn.get_color({a2, 2, 0}) == conn.get_color({d0, 2, 0}))
     throw std::runtime_error("a is disjoint from d");
 
   boost::filesystem::remove_all(th.tile_dir());

--- a/valhalla/baldr/connectivity_map.h
+++ b/valhalla/baldr/connectivity_map.h
@@ -2,9 +2,11 @@
 #define VALHALLA_BALDR_CONNECTIVITY_MAP_H_
 
 #include <valhalla/baldr/tilehierarchy.h>
+#include <valhalla/baldr/pathlocation.h>
 
 #include <vector>
 #include <unordered_map>
+#include <unordered_set>
 #include <cstdint>
 
 namespace valhalla {
@@ -25,6 +27,16 @@ namespace valhalla {
        * @return color  the color
        */
       size_t get_color(const GraphId& id) const;
+
+      /**
+       * Returns the colors for the given level,point,radius
+       *
+       * @param hierarchy_level  the hierarchy level whos connectivity you are querying
+       * @param center           the center of the circle
+       * @param radius           the radius of the circle
+       * @return colors          the colors of the tiles that intersect this circle at this level
+       */
+      std::unordered_set<size_t> get_colors(uint32_t hierarchy_level, const baldr::PathLocation& location, float radius) const;
 
       /**
        * Returns the geojson representing the connectivity map

--- a/valhalla/baldr/graphreader.h
+++ b/valhalla/baldr/graphreader.h
@@ -32,18 +32,6 @@ class GraphReader {
   static bool DoesTileExist(const TileHierarchy& tile_hierarchy, const GraphId& graphid);
 
   /**
-   * Returns true connectivity exists between the two tile ids
-   * Note: the connectivity may not be routable or may fail for other reasons
-   * the expectation is that the caller knows that this is best case
-   * scenario. The main use case is to quickly reject two disjoint locations
-   *
-   * @param  GraphId  the first tile to check
-   * @param  GraphId  the second tile to check
-   * @return bool     whether or not they are in the same connected region
-   */
-  bool AreConnected(const GraphId& first, const GraphId& second) const;
-
-  /**
    * Get a pointer to a graph tile object given a GraphId.
    * @param graphid  the graphid of the tile
    * @return GraphTile* a pointer to the graph tile

--- a/valhalla/baldr/pathlocation.h
+++ b/valhalla/baldr/pathlocation.h
@@ -15,7 +15,7 @@ namespace baldr{
  * The graph correlated location object providing the path finding
  * algorithm the information to actually compute a path
  */
-class PathLocation : public Location {
+struct PathLocation : public Location {
  public:
   using Location::Location;
   PathLocation(const Location& location);
@@ -25,59 +25,27 @@ class PathLocation : public Location {
    */
   enum SideOfStreet { NONE = 0, LEFT, RIGHT };
   struct PathEdge {
-    PathEdge(const GraphId& id, const float dist, const SideOfStreet sos = NONE);
+    PathEdge(const GraphId& id, const float dist, const midgard::PointLL& projected, const SideOfStreet sos = NONE);
     //the directed edge it appears on
     GraphId id;
     //how far along the edge it is (as a percentage  from 0 - 1)
     float dist;
+    //the projected point along the edge where the original location correlates
+    midgard::PointLL projected;
     //what side of the edge is it on
     SideOfStreet sos;
+    //whether or not this correlation point is the begin node of this edge
+    bool begin_node() const;
+    //whether or not this correlation point is the end node of this edge
+    bool end_node() const;
+
+    //a confidence interval of how good the correlation is
+    //proportional to the distance between the input point and the correlated one
+    //float correlation_quality;
   };
 
-  /**
-   * Get the edges associated with this location
-   * @return edges
-   */
-  const std::vector<PathEdge>& edges() const;
-
-  /*
-   * Get the vertex associated with this location
-   * @return vertex
-   */
-  const midgard::PointLL& vertex() const;
-
-  /**
-   * Whether or not this location is on a vertex in the graph (intersection)
-   * note: this implies all distances on edges are either 0's or 1's
-   *
-   * @return bool True if its on an intersection false if not
-   */
-  bool IsNode() const;
-
-  /**
-   * Adds a correlated edge to the path location
-   *
-   * @param the edge     the edge to correlate
-   */
-  void CorrelateEdge(const PathEdge& edge);
-  void CorrelateEdge(PathEdge&& edge);
-
-
-  /**
-   * @return true if the point has been correlated to the route network, false otherwise
-   */
-  bool IsCorrelated() const;
-
-  /**
-   * Set the route network correlation point for this location
-   * @param point the correlation point
-   */
-  void CorrelateVertex(const midgard::PointLL& correlated);
-
-  /**
-   * Clear the list of path edges.
-   */
-  void ClearEdges();
+  //list of edges this location appears on within the graph
+  std::vector<PathEdge> edges;
 
   /**
    * Equality check
@@ -96,21 +64,6 @@ class PathLocation : public Location {
    * @return PathLocation
    */
   static PathLocation FromPtree(const std::vector<Location>& locations, const boost::property_tree::ptree& path_location);
-
- protected:
-  //whether or not this location is on a vertex in the graph (intersection)
-  //note: this implies all distances on edges are either 0's or 1's
-  bool node_;
-
-  //list of edges this location appears on within the graph
-  std::vector<PathEdge> edges_;
-
-  //correlated point in the graph (along an edge or at a vertex)
-  midgard::PointLL vertex_;
-
-  //a confidence interval of how good the correlation is
-  //proportional to the distance between the input point and the correlated one
-  //float correlation_quality_;
 };
 
 }


### PR DESCRIPTION
this refactors connectivity map lookups out of graph reader because the way in which loki will use it is changing.

it also refactors pathlocation so that loki can more easily have multiple matches (for islands but also for fuzzy matching and other improvements related to search scoring)