### PR TITLE
Schedule fix

### DIFF
--- a/src/baldr/datetime.cc
+++ b/src/baldr/datetime.cc
@@ -118,13 +118,8 @@ uint64_t get_service_days(boost::gregorian::date& start_date, boost::gregorian::
   else if (tile_header_date > end_date) //reject.
     return 0;
 
-  // if our start date is in the future then we must start at the tile header date
-  // since we always use the tile header date as our start date.
-  if (start_date > tile_header_date)
-    start_date = tile_header_date;
-
   // only support 60 days out.  (59 days and include the end_date = 60)
-  boost::gregorian::date enddate = start_date + boost::gregorian::days(59);
+  boost::gregorian::date enddate = tile_header_date + boost::gregorian::days(59);
 
   if (enddate <= end_date)
     end_date = enddate;
@@ -167,7 +162,7 @@ uint64_t get_service_days(boost::gregorian::date& start_date, boost::gregorian::
     }
 
     //were we supposed to be on for this day
-    if (dow_mask & dow)
+    if ((dow_mask & dow) && (itr >= start_date))
       bit_set |= static_cast<uint64_t>(1) << x;
 
     ++itr;

--- a/test/datetime.cc
+++ b/test/datetime.cc
@@ -94,6 +94,17 @@ void TryGetServiceDays(std::string begin_date, std::string end_date, uint32_t do
     throw std::runtime_error("Invalid bits set for service days. " + begin_date + " " + end_date + " " + std::to_string(days));
 }
 
+void TryGetServiceDays(std::string tile_date, std::string begin_date, std::string end_date, uint32_t dow_mask, uint64_t value) {
+
+  auto t = DateTime::get_formatted_date(tile_date);
+  auto b = DateTime::get_formatted_date(begin_date);
+  auto e = DateTime::get_formatted_date(end_date);
+  uint64_t days = DateTime::get_service_days(b, e, DateTime::days_from_pivot_date(t), dow_mask);
+
+  if (value != days)
+    throw std::runtime_error("Invalid bits set for service days. " + begin_date + " " + end_date + " " + std::to_string(days));
+}
+
 void TryIsServiceAvailable(std::string begin_date, std::string date, std::string end_date,uint64_t days, bool value) {
 
   auto b = DateTime::days_from_pivot_date(DateTime::get_formatted_date(begin_date));
@@ -356,6 +367,15 @@ void TestServiceDays() {
 
   //Test to confirm that enddate is cut off at 60 days
   TryTestServiceEndDate("2015-09-25", "2017-09-28", "2015-11-23", dow_mask);
+
+  //Start date is after the tile date but before end date.
+  TryGetServiceDays("2016-08-03", "2016-09-01", "2016-10-28", dow_mask, 562843568692002816);
+
+  //Start date before tile date.
+  TryGetServiceDays("2016-08-03", "2016-07-05", "2016-08-31", dow_mask, 486142951);
+
+  //Start date is in the future.
+  TryGetServiceDays("2016-08-03", "2016-10-28", "2016-12-28", dow_mask, 0);
 
 }
 


### PR DESCRIPTION
Old logic would add schedule to the data and start it at the tile date and not the true start date.  This caused unnecessary transfers.  New tests added.

Amtrak transfer issue:

![screenshot from 2016-08-05 09 58 30](https://cloud.githubusercontent.com/assets/2676277/17440259/e0e73c14-5af9-11e6-8249-7915e6eae93c.png)
