### PR TITLE
Set maximum values for trip Id and headsign offset.

### DIFF
--- a/src/baldr/transitdeparture.cc
+++ b/src/baldr/transitdeparture.cc
@@ -12,9 +12,7 @@ TransitDeparture::TransitDeparture(const uint32_t lineid,
                  const uint32_t headsign_offset,
                  const uint32_t departure_time,
                  const uint32_t elapsed_time,
-                 const uint32_t schedule_index)
-    : tripid_(tripid),
-      headsign_offset_(headsign_offset) {
+                 const uint32_t schedule_index) {
   // Protect against exceeding max. values
   if (lineid > kMaxTransitLineId) {
     throw std::runtime_error("Exceeded maximum transit line Ids per tile");
@@ -25,6 +23,16 @@ TransitDeparture::TransitDeparture(const uint32_t lineid,
     throw std::runtime_error("Exceeded maximum transit routes per tile");
   }
   routeid_ = routeid;
+
+  if (tripid > kMaxTripId) {
+    throw std::runtime_error("Exceeded maximum trip Id");
+  }
+  tripid_ = tripid;
+
+  if (headsign_offset > kMaxHeadsignOffset) {
+    throw std::runtime_error("Exceeded maximum headsign offset");
+  }
+  headsign_offset_ = headsign_offset;
 
   if (blockid > kMaxTransitBlockId) {
     throw std::runtime_error("Exceeded maximum transit block Id");

--- a/valhalla/baldr/graphconstants.h
+++ b/valhalla/baldr/graphconstants.h
@@ -27,6 +27,8 @@ constexpr uint32_t kMaxTransitBlockId       = 1048575;
 constexpr uint32_t kMaxTransitLineId        = 1048576;
 constexpr uint32_t kMaxTransitDepartureTime = 131071;
 constexpr uint32_t kMaxTransitElapsedTime   = 32767;
+constexpr uint32_t kMaxTripId               = 536870912;  // 29 bits
+constexpr uint32_t kMaxHeadsignOffset       = 16777216;   // 24 bits
 
 // Payment constants. Bit constants.
 constexpr uint8_t kCoins  = 1; // Coins


### PR DESCRIPTION
Will allow us to work with bit fields to allow higher elapsed time values. 