### PR TITLE
make binary search faster, add wheelchair and bike to departure lookup

### DIFF
--- a/src/baldr/graphtile.cc
+++ b/src/baldr/graphtile.cc
@@ -421,44 +421,37 @@ std::vector<SignInfo> GraphTile::GetSigns(const uint32_t idx) const {
     return signs;
   }
 
-  // Binary search
+  // Signs are sorted by edge index.
+  // Binary search to find a sign with matching edge index.
   int32_t low = 0;
   int32_t high = count-1;
   int32_t mid;
-  bool found = false;
+  int32_t found = count;
   while (low <= high) {
     mid = (low + high) / 2;
-    if (signs_[mid].edgeindex() == idx) {
-      found = true;
-      break;
-    }
-    if (idx < signs_[mid].edgeindex() ) {
+    const auto& sign = signs_[mid];
+    //matching lineid and a workable time
+    if (idx == sign.edgeindex()) {
+      found = mid;
       high = mid - 1;
-    } else {
+    }//need a smaller lineid
+    else if (idx < sign.edgeindex()) {
+      high = mid - 1;
+    }//either need a bigger lineid or a later time
+    else {
       low = mid + 1;
     }
   }
 
-  if (found) {
-    // Back up while prior is equal (or at the beginning)
-    while (mid > 0 && signs_[mid-1].edgeindex() == idx) {
-      mid--;
-    }
-
-    // Add signs
-    while (signs_[mid].edgeindex() == idx && mid < count) {
-      if (signs_[mid].text_offset() < textlist_size_) {
-        signs.emplace_back(signs_[mid].type(),
-                (textlist_ + signs_[mid].text_offset()));
-      } else {
-        throw std::runtime_error("GetSigns: offset exceeds size of text list");
-      }
-      mid++;
-    }
+  // Add signs
+  for(; found < count && signs_[found].edgeindex() == idx; ++found) {
+    if (signs_[found].text_offset() < textlist_size_)
+      signs.emplace_back(signs_[found].type(), (textlist_ + signs_[found].text_offset()));
+    else
+      throw std::runtime_error("GetSigns: offset exceeds size of text list");
   }
-  if (signs.size() == 0) {
+  if (signs.size() == 0)
     LOG_ERROR("No signs found for idx = " + std::to_string(idx));
-  }
   return signs;
 }
 
@@ -466,7 +459,8 @@ std::vector<SignInfo> GraphTile::GetSigns(const uint32_t idx) const {
 // time (seconds from midnight).
 const TransitDeparture* GraphTile::GetNextDeparture(const uint32_t lineid,
                  const uint32_t current_time, const uint32_t day,
-                 const uint32_t dow, bool date_before_tile) const {
+                 const uint32_t dow, bool date_before_tile,
+                 bool wheelchair, bool bicycle) const {
   uint32_t count = header_->departurecount();
   if (count == 0) {
     return nullptr;
@@ -477,51 +471,32 @@ const TransitDeparture* GraphTile::GetNextDeparture(const uint32_t lineid,
   int32_t low = 0;
   int32_t high = count-1;
   int32_t mid;
-  bool found = false;
+  int32_t found = count;
   while (low <= high) {
     mid = (low + high) / 2;
-    if (departures_[mid].lineid() == lineid) {
-      found = true;
-      break;
-    }
-    if (lineid < departures_[mid].lineid()) {
+    const auto& dep = departures_[mid];
+    //matching lineid and a workable time
+    if (lineid == dep.lineid() && current_time <= dep.departure_time()) {
+      found = mid;
       high = mid - 1;
-    } else {
+    }//need a smaller lineid
+    else if (lineid < dep.lineid()) {
+      high = mid - 1;
+    }//either need a bigger lineid or a later time
+    else {
       low = mid + 1;
     }
   }
 
-  if (!found) {
-    LOG_DEBUG("No departures found for lineid = " + std::to_string(lineid));
-    return nullptr;
-  }
-
-  // Back up until the prior departure from this edge has departure time
-  // less than the current time
-  while (mid > 0 &&
-         departures_[mid-1].lineid() == lineid &&
-         departures_[mid-1].departure_time() >= current_time) {
-    mid--;
-  }
-
   // Iterate through departures until one is found with valid date, dow or
   // calendar date, and does not have a calendar exception.
-  const TransitDeparture* dep = &departures_[mid];
-  while (true) {
+  for(; found < count && departures_[found].lineid() == lineid; ++found) {
     // Make sure valid departure time
-    if (dep->departure_time() >= current_time) {
-      if (GetTransitSchedule(dep->schedule_index())->IsValid(day, dow, date_before_tile)) {
-        return dep;
-      }
-    }
-
-    // Advance to next departure and break if
-    if (mid++ == count) {
-      break;
-    }
-    dep++;
-    if (dep->lineid() != lineid) {
-      break;
+    if (departures_[found].departure_time() >= current_time &&
+      GetTransitSchedule(departures_[found].schedule_index())->IsValid(day, dow, date_before_tile) &&
+      (!wheelchair || wheelchair == departures_[found].wheelchair_accessible()) &&
+      (!bicycle || bicycle == departures_[found].bicycle_accessible())) {
+      return &departures_[found];
     }
   }
 
@@ -540,47 +515,31 @@ const TransitDeparture* GraphTile::GetTransitDeparture(const uint32_t lineid,
   }
 
   // Departures are sorted by edge Id and then by departure time.
-  // Binary search to find a departure with matching edge Id.
+  // Binary search to find a departure with matching line Id.
   int32_t low = 0;
   int32_t high = count-1;
   int32_t mid;
-  bool found = false;
+  int32_t found = count;
   while (low <= high) {
     mid = (low + high) / 2;
-    if (departures_[mid].lineid() == lineid) {
-      found = true;
-      break;
-    }
-    if (lineid < departures_[mid].lineid() ) {
+    const auto& dep = departures_[mid];
+    //find the first matching lineid in the list
+    if (lineid == dep.lineid()) {
+      found = mid;
       high = mid - 1;
-    } else {
+    }//need a smaller lineid
+    else if (lineid < dep.lineid()) {
+      high = mid - 1;
+    }//need a bigger lineid
+    else {
       low = mid + 1;
     }
   }
 
-  if (!found) {
-    LOG_INFO("No departures found for lineid = " + std::to_string(lineid) +
-             " and tripid = " + std::to_string(tripid));
-    return nullptr;
-  }
-
-  if (found) {
-    // Back up while prior is equal (or at the beginning)
-    while (mid > 0 && departures_[mid-1].lineid() == lineid) {
-
-      if (departures_[mid].tripid() == tripid)
-        return &departures_[mid];
-
-      mid--;
-    }
-
-    while (departures_[mid].tripid() != tripid && mid < count) {
-      mid++;
-    }
-
-    if (departures_[mid].tripid() == tripid)
-      return &departures_[mid];
-  }
+  // Iterate through departures until one is found with matching trip id
+  for(; found < count && departures_[found].lineid() == lineid; ++found)
+    if (departures_[found].tripid() == tripid)
+      return &departures_[found];
 
   LOG_INFO("No departures found for lineid = " + std::to_string(lineid) +
            " and tripid = " + std::to_string(tripid));
@@ -667,40 +626,30 @@ std::vector<AccessRestriction> GraphTile::GetAccessRestrictions(const uint32_t i
   int32_t low = 0;
   int32_t high = count-1;
   int32_t mid;
-  bool found = false;
+  int32_t found = count;
   while (low <= high) {
     mid = (low + high) / 2;
-    if (access_restrictions_[mid].edgeindex() == idx) {
-      found = true;
-      break;
-    }
-    if (idx < access_restrictions_[mid].edgeindex() ) {
+    const auto& res = access_restrictions_[mid];
+    //find the first matching index in the list
+    if (idx == res.edgeindex()) {
+      found = mid;
       high = mid - 1;
-    } else {
+    }//need a smaller index
+    else if (idx < res.edgeindex()) {
+      high = mid - 1;
+    }//need a bigger index
+    else {
       low = mid + 1;
     }
   }
 
-  if (!found) {
+  // Add restrictions for only the access that we are interested in
+  for (; found < count && access_restrictions_[found].edgeindex() == idx; ++found)
+    if (access_restrictions_[found].modes() & access)
+      restrictions.emplace_back(access_restrictions_[found]);
+
+  if (restrictions.size() == 0)
     LOG_ERROR("No restrictions found for edge index = " + std::to_string(idx));
-    return restrictions;
-  }
-
-  // Back up while prior is equal (or at the beginning)
-  while (mid > 0 && access_restrictions_[mid - 1].edgeindex() == idx) {
-    mid--;
-  }
-
-  while (access_restrictions_[mid].edgeindex() == idx && mid < count) {
-    // Add restrictions for only the access that we are interested in
-    if (access_restrictions_[mid].modes() & access)
-      restrictions.emplace_back(access_restrictions_[mid]);
-    mid++;
-  }
-
-  if (restrictions.size() == 0) {
-    LOG_ERROR("No restrictions found for edge index = " + std::to_string(idx));
-  }
   return restrictions;
 }
 

--- a/src/baldr/graphtile.cc
+++ b/src/baldr/graphtile.cc
@@ -430,14 +430,14 @@ std::vector<SignInfo> GraphTile::GetSigns(const uint32_t idx) const {
   while (low <= high) {
     mid = (low + high) / 2;
     const auto& sign = signs_[mid];
-    //matching lineid and a workable time
+    //matching edge index
     if (idx == sign.edgeindex()) {
       found = mid;
       high = mid - 1;
-    }//need a smaller lineid
+    }//need a smaller index
     else if (idx < sign.edgeindex()) {
       high = mid - 1;
-    }//either need a bigger lineid or a later time
+    }//need a bigger index
     else {
       low = mid + 1;
     }

--- a/src/baldr/graphtile.cc
+++ b/src/baldr/graphtile.cc
@@ -494,8 +494,8 @@ const TransitDeparture* GraphTile::GetNextDeparture(const uint32_t lineid,
     // Make sure valid departure time
     if (departures_[found].departure_time() >= current_time &&
       GetTransitSchedule(departures_[found].schedule_index())->IsValid(day, dow, date_before_tile) &&
-      (!wheelchair || wheelchair == departures_[found].wheelchair_accessible()) &&
-      (!bicycle || bicycle == departures_[found].bicycle_accessible())) {
+      (!wheelchair || departures_[found].wheelchair_accessible()) &&
+      (!bicycle || departures_[found].bicycle_accessible())) {
       return &departures_[found];
     }
   }

--- a/valhalla/baldr/graphtile.h
+++ b/valhalla/baldr/graphtile.h
@@ -206,8 +206,8 @@ class GraphTile {
                                            const uint32_t day,
                                            const uint32_t dow,
                                            bool  date_before_tile,
-                                           bool wheelchair = false,
-                                           bool bicycle = false) const;
+                                           bool wheelchair,
+                                           bool bicycle) const;
 
   /**
    * Get the departure given the directed edge Id and tripid

--- a/valhalla/baldr/graphtile.h
+++ b/valhalla/baldr/graphtile.h
@@ -196,6 +196,8 @@ class GraphTile {
    * @param   dow               Day of week (see graphconstants.h)
    * @param   date_before_tile  Is the date that was inputed before
    *                            the tile creation date?
+   * @param   wheelchair        Only find departures with wheelchair access if true
+   * @param   bicyle            Only find departures with bicycle access if true
    * @return  Returns a pointer to the transit departure information.
    *          Returns nullptr if no departures are found.
    */
@@ -203,7 +205,9 @@ class GraphTile {
                                            const uint32_t current_time,
                                            const uint32_t day,
                                            const uint32_t dow,
-                                           bool  date_before_tile) const;
+                                           bool  date_before_tile,
+                                           bool wheelchair = false,
+                                           bool bicycle = false) const;
 
   /**
    * Get the departure given the directed edge Id and tripid


### PR DESCRIPTION
instead of spooling back to the beginning to get the first matching record ive slightly modified the 4 binary searches to find the first matching record. ive also simplified the logic after each one for the various other criteria.

in addition to that when asking for the next departure you can also specify that you need one that supports bike and/or wheelchair