### PR TITLE
graphreader is the arbitor of tiles

### DIFF
--- a/test/graphreader.cc
+++ b/test/graphreader.cc
@@ -104,7 +104,7 @@ void TestConnectivityMap() {
   touch_tile(d1, th);
 
   //check that it looks right
-  connectivity_map_t conn(th);
+  connectivity_map_t conn(pt);
   if(conn.get_color({a0, 2, 0}) != conn.get_color({a1, 2, 0}))
     throw std::runtime_error("a's should be connected");
   if(conn.get_color({a0, 2, 0}) != conn.get_color({a2, 2, 0}))

--- a/valhalla/baldr/connectivity_map.h
+++ b/valhalla/baldr/connectivity_map.h
@@ -15,10 +15,10 @@ namespace valhalla {
     class connectivity_map_t {
      public:
       /**
-       * Constructus the connectivity map
-       *
+       * Constructs the connectivity map
+       * @param pt   the ptree sub child labeled mjolnir in the valhalla json config
        */
-      connectivity_map_t(const TileHierarchy& tile_hierarchy);
+      connectivity_map_t(const boost::property_tree::ptree& pt);
 
       /**
        * Returns the color for the given graphid

--- a/valhalla/baldr/graphreader.h
+++ b/valhalla/baldr/graphreader.h
@@ -107,6 +107,12 @@ class GraphReader {
    */
   uint32_t GetEdgeDensity(const GraphId& edgeid);
 
+  /**
+   * Gets back a set of available tiles
+   * @return  returns the list of available tiles
+   */
+  std::unordered_set<GraphId> GetTileSet() const;
+
  protected:
   // (Tar) extract of tiles - the contents are empty if not being used
   struct tile_extract_t;

--- a/valhalla/baldr/tilehierarchy.h
+++ b/valhalla/baldr/tilehierarchy.h
@@ -16,6 +16,11 @@ namespace valhalla {
 namespace baldr {
 
 
+//TODO: hack and slash this. this should just be the levels and operations we commonly do
+//with them like getting the transit level or getting the highest or lowest non transit level
+//this can be static and accessed through a singleton or just static functions on the struct
+//tile_dir doesnt belong here anyway
+
 /**
  * class used to get information about a given hierarchy of tiles
  */


### PR DESCRIPTION
so connectivity map was broken because it rolled its own t hing for looking at what tiles we have. this is the first step to making graphreader the sole controller of knowing where tiles are (for reading at least). ive added a comment to tilehierarchy for the rest of the work but it has a lot of side effects so i climbed back out of that rabbit hole for now.