### PR TITLE
dont copy the shape bytes into a string to decode them

### DIFF
--- a/src/baldr/edgeinfo.cc
+++ b/src/baldr/edgeinfo.cc
@@ -81,13 +81,8 @@ std::vector<std::string> EdgeInfo::GetNames() const {
 // Returns shape as a vector of PointLL
 const std::vector<PointLL>& EdgeInfo::shape() const {
   //if we haven't yet decoded the shape, do so
-  if(encoded_shape_ != nullptr) {
-    shape_ = midgard::decode7<std::vector<PointLL> >(std::string(encoded_shape_,
-                                  item_->encoded_shape_size));
-    encoded_shape_ = nullptr;
-  }
-
-  //hand it back
+  if(encoded_shape_ != nullptr && shape_.empty())
+    shape_ = midgard::decode7<std::vector<PointLL> >(encoded_shape_, item_->encoded_shape_size);
   return shape_;
 }
 
@@ -97,13 +92,10 @@ std::string EdgeInfo::encoded_shape() const {
 }
 
 json::MapPtr EdgeInfo::json() const {
-  auto encoded = midgard::encode(nullptr ? shape_ :
-    midgard::decode7<std::vector<PointLL> >(std::string(encoded_shape_, item_->encoded_shape_size)));
-
   return json::map({
     {"way_id", static_cast<uint64_t>(wayid_)},
     {"names", names_json(GetNames())},
-    {"shape", encoded},
+    {"shape", encoded_shape()},
   });
 }
 

--- a/src/baldr/geojson.cc
+++ b/src/baldr/geojson.cc
@@ -59,8 +59,8 @@ MapPtr to_geojson(const typename midgard::GriddedData<coord_t>::contours_t& grid
           })},
           {"properties", map({
             {"contour", static_cast<uint64_t>(contours.first)},
-            {"fill", hex.str()},
-            {"fill-opacity", json::fp_t{.33f, 2}},
+            { polygon ? "fill" : "color", hex.str()},
+            { polygon ? "fill-opacity" : "opacity", json::fp_t{.33f, 2}},
           })},
         })
       );


### PR DESCRIPTION
dont copy the encoded linestring when decoding it, this is an effort to provide an alternative to #298 as outlined by @TeXitoi 