### PR TITLE
Add edge merging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ test/admin
 test/datetime
 test/directededge
 test/double_bucket_queue
+test/edgecollapser
 test/graphid
 test/tilehierarchy
 test/graphtile

--- a/Makefile.am
+++ b/Makefile.am
@@ -104,6 +104,7 @@ libvalhalla_baldr_la_SOURCES = \
 	src/baldr/graphreader.cc \
 	src/baldr/graphtile.cc \
 	src/baldr/graphtileheader.cc \
+	src/baldr/merge.cc \
 	src/baldr/nodeinfo.cc \
 	src/baldr/location.cc \
 	src/baldr/pathlocation.cc \
@@ -137,6 +138,7 @@ check_PROGRAMS = \
 	test/datetime \
 	test/directededge \
 	test/double_bucket_queue \
+	test/edgecollapser \
 	test/graphid \
 	test/tilehierarchy \
 	test/graphtile \
@@ -168,6 +170,9 @@ test_datetime_LDADD = $(DEPS_LIBS) $(VALHALLA_DEPS_LIBS) libvalhalla_baldr.la
 test_directededge_SOURCES = test/directededge.cc test/test.cc
 test_directededge_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_DEPS_CFLAGS)
 test_directededge_LDADD = $(DEPS_LIBS) $(VALHALLA_DEPS_LIBS) libvalhalla_baldr.la
+test_edgecollapser_SOURCES = test/edgecollapser.cc test/test.cc
+test_edgecollapser_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_DEPS_CFLAGS)
+test_edgecollapser_LDADD = $(DEPS_LIBS) $(VALHALLA_DEPS_LIBS) libvalhalla_baldr.la
 test_graphid_SOURCES = test/graphid.cc test/test.cc
 test_graphid_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_DEPS_CFLAGS)
 test_graphid_LDADD = $(DEPS_LIBS) $(VALHALLA_DEPS_LIBS) libvalhalla_baldr.la

--- a/src/baldr/graphreader.cc
+++ b/src/baldr/graphreader.cc
@@ -74,6 +74,8 @@ GraphReader::GraphReader(const boost::property_tree::ptree& pt)
 bool GraphReader::DoesTileExist(const GraphId& graphid) const {
   if(tile_extract_->tiles.find(graphid) != tile_extract_->tiles.cend())
     return true;
+  if(cache_.find(graphid) != cache_.end())
+    return true;
   std::string file_location = tile_hierarchy_.tile_dir() + "/" +
     GraphTile::FileSuffix(graphid.Tile_Base(), tile_hierarchy_);
   struct stat buffer;

--- a/src/baldr/merge.cc
+++ b/src/baldr/merge.cc
@@ -117,9 +117,10 @@ void edge_tracker::set(const GraphId &edge_id) {
   m_edge_set.set(edge_id.id() + itr->second);
 }
 
-edge_collapser::edge_collapser(GraphReader &reader, edge_tracker &tracker, std::function<void(const path &)> func)
+edge_collapser::edge_collapser(GraphReader &reader, edge_tracker &tracker, std::function<bool(const DirectedEdge *)> edge_pred, std::function<void(const path &)> func)
   : m_reader(reader)
   , m_tracker(tracker)
+  , m_edge_predictate(edge_pred)
   , m_func(func)
 {}
 
@@ -133,9 +134,7 @@ std::pair<GraphId, GraphId> edge_collapser::nodes_reachable_from(GraphId node_id
   for (const auto &edge : iter::edges(m_reader, node_id)) {
     // nodes which connect to ferries, transit or to a different level
     // shouldn't be collapsed.
-    if (edge.first->use() == Use::kFerry ||
-        edge.first->use() == Use::kTransitConnection ||
-        edge.first->trans_up() || edge.first->trans_down()) {
+    if (!m_edge_predictate(edge.first)) {
       return none;
     }
 

--- a/src/baldr/merge.cc
+++ b/src/baldr/merge.cc
@@ -114,13 +114,10 @@ edge_tracker::edge_index_t edge_tracker::edges_in_tiles(GraphReader &reader) {
         edges_in_tiles.emplace(tile_id, edge_count);
         const auto* tile = reader.GetGraphTile(tile_id);
         edge_count += tile->header()->directededgecount();
-        // this clears the cache, and the test relies on being able to inject
-        // stuff into the cache :-(
-        //
-        // TODO: presumably this is bad when the cache doesn't behave like a
-        // cache and evict older tiles. but this shouldn't be a problem when
-        // mmapping the whole extract.
-        //reader.Clear();
+        // clear the cache if it is overcommitted to avoid running out of memory.
+        if (reader.OverCommitted()) {
+          reader.Clear();
+        }
       }
     }
   }

--- a/src/baldr/merge.cc
+++ b/src/baldr/merge.cc
@@ -104,7 +104,6 @@ edge_tracker::edge_index_t edge_tracker::edges_in_tiles(GraphReader &reader) {
 
   //keep the global number of edges encountered at the point we encounter each tile
   //this allows an edge to have a sequential global id and makes storing it very small
-  LOG_INFO("Enumerating edges...");
   uint64_t edge_count = 0;
   edge_tracker::edge_index_t edges_in_tiles(tiles_in_levels);
   for (auto level : reader.GetTileHierarchy().levels() | bra::map_values) {
@@ -141,7 +140,6 @@ bitset_t edge_tracker::count_all_edges(GraphReader &reader, const edge_tracker::
 
   const auto* tile = reader.GetGraphTile(max_tile_id);
   edge_count += tile->header()->directededgecount();
-  LOG_INFO("Number of edges: " + std::to_string(edge_count));
   return bitset_t(edge_count);
 }
 

--- a/src/baldr/merge.cc
+++ b/src/baldr/merge.cc
@@ -122,7 +122,7 @@ edge_tracker::edge_index_t edge_tracker::edges_in_tiles(GraphReader &reader) {
     }
   }
 
-  return std::move(edges_in_tiles);
+  return edges_in_tiles;
 }
 
 bitset_t edge_tracker::count_all_edges(GraphReader &reader, const edge_tracker::edge_index_t &edges) {

--- a/src/baldr/merge.cc
+++ b/src/baldr/merge.cc
@@ -142,9 +142,9 @@ bitset_t edge_tracker::count_all_edges(GraphReader &reader, const edge_tracker::
 
 namespace iter {
 
-// edges provides a container wrapper for the edges leaving a node which is
-// compatible with C++ range-based for loops and can make reading code a bit
-// nicer. for example:
+// the "edges" struct provides a container wrapper for the edges leaving a node
+// which is compatible with C++ range-based for loops and can make reading code
+// a bit nicer. for example:
 //
 //     for (const auto &pair : iter::edges(reader, node_id)) {
 //       ...

--- a/src/baldr/merge.cc
+++ b/src/baldr/merge.cc
@@ -1,0 +1,402 @@
+#include "valhalla/baldr/merge.h"
+#include "valhalla/baldr/graphreader.h"
+#include "valhalla/midgard/logging.h"
+
+#include <boost/range/adaptor/map.hpp>
+#include <boost/optional.hpp>
+
+namespace bra = boost::adaptors;
+
+namespace valhalla {
+namespace baldr {
+namespace merge {
+
+namespace {
+
+//a place we can mark what edges we've seen, even for the planet we should need < 100mb
+struct bitset_t {
+  bitset_t(size_t size) {bits.resize(size);}
+  void set(const uint64_t id) {
+    if (id >= static_cast<uint64_t>(bits.size()) * 64) throw std::runtime_error("id out of bounds");
+    bits[id / 64] |= static_cast<uint64_t>(1) << (id % static_cast<uint64_t>(64));
+  }
+  bool get(const uint64_t id) const {
+    if (id >= static_cast<uint64_t>(bits.size()) * 64) throw std::runtime_error("id out of bounds");
+    return bits[id / 64] & (static_cast<uint64_t>(1) << (id % static_cast<uint64_t>(64)));
+  }
+protected:
+  std::vector<uint64_t> bits;
+};
+
+struct edge_tracker {
+  explicit edge_tracker(GraphReader &reader);
+
+  bool get(const GraphId &edge_id) const;
+  void set(const GraphId &edge_id);
+
+  typedef std::unordered_map<GraphId, uint64_t> edge_index_t;
+  edge_index_t m_edges_in_tiles;
+  //this is how we know what i've touched and what we havent
+  bitset_t m_edge_set;
+
+  static bitset_t count_all_edges(GraphReader &reader, const edge_index_t &edges);
+  static edge_index_t edges_in_tiles(GraphReader &reader);
+};
+
+edge_tracker::edge_tracker(GraphReader &reader)
+  : m_edges_in_tiles(edges_in_tiles(reader))
+  , m_edge_set(count_all_edges(reader, m_edges_in_tiles)) {
+}
+
+bool edge_tracker::get(const GraphId &edge_id) const {
+  auto itr = m_edges_in_tiles.find(edge_id.Tile_Base());
+  assert(itr != m_edges_in_tiles.end());
+  return m_edge_set.get(edge_id.id() + itr->second);
+}
+
+void edge_tracker::set(const GraphId &edge_id) {
+  auto itr = m_edges_in_tiles.find(edge_id.Tile_Base());
+  assert(itr != m_edges_in_tiles.end());
+  m_edge_set.set(edge_id.id() + itr->second);
+}
+
+uint64_t count_tiles_in_levels(GraphReader &reader) {
+  uint64_t tile_count = 0;
+  for (auto level : reader.GetTileHierarchy().levels() | bra::map_values) {
+    tile_count += level.tiles.ncolumns() * level.tiles.nrows();
+  }
+  return tile_count;
+}
+
+edge_tracker::edge_index_t edge_tracker::edges_in_tiles(GraphReader &reader) {
+  uint64_t tiles_in_levels = count_tiles_in_levels(reader);
+
+  //keep the global number of edges encountered at the point we encounter each tile
+  //this allows an edge to have a sequential global id and makes storing it very small
+  LOG_INFO("Enumerating edges...");
+  uint64_t edge_count = 0;
+  edge_tracker::edge_index_t edges_in_tiles(tiles_in_levels);
+  for (auto level : reader.GetTileHierarchy().levels() | bra::map_values) {
+    for (uint32_t i = 0; i < level.tiles.TileCount(); ++i) {
+      GraphId tile_id{i, level.level, 0};
+      if (reader.DoesTileExist(tile_id)) {
+        //TODO: just read the header, parsing the whole thing isnt worth it at this point
+        edges_in_tiles.emplace(tile_id, edge_count);
+        const auto* tile = reader.GetGraphTile(tile_id);
+        edge_count += tile->header()->directededgecount();
+        // this clears the cache, and the test relies on being able to inject
+        // stuff into the cache :-(
+        //reader.Clear();
+      }
+    }
+  }
+
+  return std::move(edges_in_tiles);
+}
+
+bitset_t edge_tracker::count_all_edges(GraphReader &reader, const edge_tracker::edge_index_t &edges) {
+  GraphId max_tile_id;
+  uint64_t edge_count = 0;
+  for (const auto &entry : edges) {
+    if (entry.second >= edge_count) {
+      edge_count = entry.second;
+      max_tile_id = entry.first;
+    }
+  }
+
+  const auto* tile = reader.GetGraphTile(max_tile_id);
+  edge_count += tile->header()->directededgecount();
+  LOG_INFO("Number of edges: " + std::to_string(edge_count));
+  return bitset_t(edge_count);
+}
+
+namespace iter {
+
+struct edges {
+  struct const_iterator {
+    const DirectedEdge *ptr;
+    GraphId id;
+
+    const_iterator() : ptr(nullptr), id(0) {}
+    const_iterator(const DirectedEdge *p, GraphId i) : ptr(p), id(i) {}
+
+    const_iterator operator+(uint64_t i) const {
+      return const_iterator(ptr + i, id + i);
+    }
+
+    const_iterator &operator++() {
+      ++ptr;
+      id++;
+      return *this;
+    }
+
+    const_iterator operator++(int) {
+      const_iterator ret = *this;
+      ++(*this);
+      return ret;
+    }
+
+    std::pair<const DirectedEdge *const, GraphId> operator*() const {
+      return std::pair<const DirectedEdge *const, GraphId>(ptr, GraphId(id));
+    }
+
+    bool operator!=(const const_iterator &other) const {
+      return (ptr != other.ptr) || (id != other.id);
+    }
+  };
+
+  edges(GraphReader &reader, GraphId node_id) {
+    auto *tile = reader.GetGraphTile(node_id);
+    auto *node_info = tile->node(node_id);
+
+    auto edge_idx = node_info->edge_index();
+    m_begin = const_iterator(tile->directededge(edge_idx),
+                             node_id.Tile_Base() + uint64_t(edge_idx));
+    m_end = m_begin + node_info->edge_count();
+  }
+
+  const_iterator begin() const { return m_begin; }
+  const_iterator end()   const { return m_end; }
+
+private:
+  const_iterator m_begin, m_end;
+};
+
+} // namespace iter
+
+struct edge_collapser {
+  edge_collapser(GraphReader &reader, edge_tracker &tracker, std::function<void(const path &)> func)
+    : m_reader(reader)
+    , m_tracker(tracker)
+    , m_func(func)
+    {}
+
+  // returns the pair of nodes reachable from the given @node_id where they
+  // are the only two nodes reachable by non-shortcut edges, and none of the
+  // edges of @node_id cross into a different level.
+  boost::optional<std::pair<GraphId, GraphId> > nodes_reachable_from(GraphId node_id) {
+    boost::optional<GraphId> first, second;
+
+    for (const auto &edge : iter::edges(m_reader, node_id)) {
+      // nodes which connect to ferries, transit or to a different level
+      // shouldn't be collapsed.
+      if (edge.first->use() == Use::kFerry ||
+          edge.first->use() == Use::kTransitConnection ||
+          edge.first->trans_up() || edge.first->trans_down()) {
+        return boost::none;
+      }
+
+      // shortcut edges should be ignored
+      if (edge.first->shortcut()) {
+        continue;
+      }
+
+      if (first) {
+        if (second) {
+          // can't add a third, that means this node is a true junction.
+          return boost::none;
+
+        } else {
+          second = edge.first->endnode();
+        }
+      } else {
+        first = edge.first->endnode();
+      }
+    }
+
+    if (first && second) {
+      return std::make_pair(*first, *second);
+    } else {
+      return boost::none;
+    }
+  }
+
+  boost::optional<GraphId> next_node_id(GraphId last_node_id, GraphId node_id) {
+    //
+    //        -->--     -->--
+    //   \   /  e4 \   /  e1 \   /
+    //   -(p)       (c)       (n)-
+    //   /   \ e3  /   \ e2  /   \
+    //        --<--     --<--
+    //
+    // given p (last_node_id) and c (node_id), return n if there is such a node.
+    auto nodes = nodes_reachable_from(node_id);
+    if (!nodes) {
+      return boost::none;
+    }
+    assert(nodes->first == last_node_id || nodes->second == last_node_id);
+    if (nodes->first == last_node_id) {
+      return nodes->second;
+    } else {
+      return nodes->first;
+    }
+  }
+
+  GraphId edge_between(GraphId cur, GraphId next) {
+    boost::optional<GraphId> edge_id;
+    for (const auto &edge : iter::edges(m_reader, cur)) {
+      if (edge.first->endnode() == next) {
+        edge_id = edge.second;
+        break;
+      }
+    }
+    assert(bool(edge_id));
+    return *edge_id;
+  }
+
+  void explore(GraphId node_id) {
+    if (m_seen_nodes.count(node_id) != 0) {
+      return;
+    }
+    m_seen_nodes.insert(node_id);
+
+    auto nodes = nodes_reachable_from(node_id);
+    if (!nodes) {
+      return;
+    }
+
+    path forward(node_id), reverse(node_id);
+
+    explore(node_id, nodes->first,  forward, reverse);
+    explore(node_id, nodes->second, reverse, forward);
+
+    m_func(forward);
+    m_func(reverse);
+  }
+
+  void explore(GraphId prev, GraphId cur, path &forward, path &reverse) {
+    const auto original_node_id = prev;
+    m_seen_nodes.insert(cur);
+
+    boost::optional<GraphId> maybe_next;
+    do {
+      auto e1 = edge_between(prev, cur);
+      forward.push_back(segment(prev, e1, cur));
+      m_tracker.set(e1);
+      auto e2 = edge_between(cur, prev);
+      reverse.push_front(segment(cur, e2, prev));
+      m_tracker.set(e2);
+
+      maybe_next = next_node_id(prev, cur);
+      if (maybe_next) {
+        prev = cur;
+        cur = *maybe_next;
+        m_seen_nodes.insert(cur);
+        if (cur == original_node_id) {
+          // circular!
+          break;
+        }
+      }
+    } while (maybe_next);
+  }
+
+private:
+  GraphReader &m_reader;
+  edge_tracker &m_tracker;
+  std::function<void(const path &)> m_func;
+  std::unordered_set<GraphId> m_seen_nodes;
+};
+
+path make_single_edge_path(GraphReader &reader, GraphId edge_id) {
+  auto *edge = reader.GetGraphTile(edge_id)->directededge(edge_id);
+  auto node_id = edge->endnode();
+  auto opp_edge_idx = edge->opp_index();
+  auto edge_idx = reader.GetGraphTile(node_id)->node(node_id)->edge_index() + opp_edge_idx;
+  GraphId opp_edge_id(node_id.tileid(), node_id.level(), edge_idx);
+  auto *opp_edge = reader.GetGraphTile(opp_edge_id)->directededge(opp_edge_id);
+  auto start_node_id = opp_edge->endnode();
+
+  path p(segment(start_node_id, edge_id, node_id));
+  return p;
+}
+
+bool check_access(GraphReader &reader, const std::deque<GraphId> &merged) {
+  uint32_t access = kAllAccess;
+  for (auto edge_id : merged) {
+    auto edge = reader.GetGraphTile(edge_id)->directededge(edge_id);
+    access &= edge->forwardaccess();
+  }
+  // be permissive here, as we do want to collect traffoc on most vehicular
+  // routes.
+  uint32_t vehicular = kAutoAccess | kTruckAccess |
+    kTaxiAccess | kBusAccess | kHOVAccess;
+  return access & vehicular;
+}
+
+
+} // anonymous namespace
+
+segment::segment(GraphId start, GraphId edge, GraphId end)
+  : m_start(start)
+  , m_edge(edge)
+  , m_end(end)
+{}
+
+path::path(segment s)
+  : m_start(s.start())
+  , m_end(s.end()) {
+  m_edges.push_back(s.edge());
+}
+
+path::path(GraphId node_id)
+  : m_start(node_id)
+  , m_end(node_id) {
+}
+
+void path::push_back(segment s) {
+  assert(s.start() == m_end);
+  m_end = s.end();
+  m_edges.push_back(s.edge());
+}
+
+void path::push_front(segment s) {
+  assert(s.end() == m_start);
+  m_start = s.start();
+  m_edges.push_front(s.edge());
+}
+
+void merge(GraphReader &reader, std::function<void(const path &)> func) {
+  auto check_func = [&](const path &p) {
+    if (check_access(reader, p.m_edges)) {
+      func(p);
+    }
+  };
+
+  edge_tracker tracker(reader);
+  edge_collapser e(reader, tracker, check_func);
+
+  for (auto level : reader.GetTileHierarchy().levels() | bra::map_values) {
+    for (uint32_t i = 0; i < level.tiles.TileCount(); ++i) {
+      GraphId tile_id{i, level.level, 0};
+      if (reader.DoesTileExist(tile_id)) {
+        const auto *tile = reader.GetGraphTile(tile_id);
+        uint32_t node_count = tile->header()->nodecount();
+        for (uint32_t i = 0; i < node_count; ++i) {
+          GraphId node_id(tile_id.tileid(), tile_id.level(), i);
+          e.explore(node_id);
+        }
+      }
+    }
+  }
+
+  for (auto level : reader.GetTileHierarchy().levels() | bra::map_values) {
+    for (uint32_t i = 0; i < level.tiles.TileCount(); ++i) {
+      GraphId tile_id{i, level.level, 0};
+      if (reader.DoesTileExist(tile_id)) {
+        const auto *tile = reader.GetGraphTile(tile_id);
+        const auto num_edges = tile->header()->directededgecount();
+        for (uint32_t i = 0; i < num_edges; ++i) {
+          GraphId edge_id(tile_id.tileid(), tile_id.level(), i);
+          if (!tracker.get(edge_id)) {
+            auto p = make_single_edge_path(reader, edge_id);
+            check_func(p);
+          }
+        }
+      }
+    }
+  }
+}
+
+}
+}
+}

--- a/src/baldr/merge.cc
+++ b/src/baldr/merge.cc
@@ -275,6 +275,11 @@ struct edge_collapser {
     return *edge_id;
   }
 
+  // explore starts walking the graph from a single node, building a forward and
+  // reverse path of edges as long as the nodes found haven't been explored
+  // before and have exactly two out-edges.
+  //
+  // the user-defined function is called for each path found.
   void explore(GraphId node_id) {
     auto nodes = nodes_reachable_from(node_id);
     if (!nodes) {
@@ -290,6 +295,8 @@ struct edge_collapser {
     m_func(reverse);
   }
 
+  // walk in a single direction, using the "direction" given by two nodes to
+  // select which edge is considered to be "forward".
   void explore(GraphId prev, GraphId cur, path &forward, path &reverse) {
     const auto original_node_id = prev;
 
@@ -320,6 +327,8 @@ private:
   std::function<void(const path &)> m_func;
 };
 
+// utility function to make a path out of a single edge. this is called once all
+// the collapsible paths have been found and single edges are all that's left.
 path make_single_edge_path(GraphReader &reader, GraphId edge_id) {
   auto *edge = reader.GetGraphTile(edge_id)->directededge(edge_id);
   auto node_id = edge->endnode();

--- a/src/merge.cpp
+++ b/src/merge.cpp
@@ -1,0 +1,1 @@
+#include "valhalla/baldr/merge.h"

--- a/src/merge.cpp
+++ b/src/merge.cpp
@@ -1,1 +1,0 @@
-#include "valhalla/baldr/merge.h"

--- a/test/edgecollapser.cc
+++ b/test/edgecollapser.cc
@@ -1,0 +1,167 @@
+#include "test.h"
+
+#include "baldr/graphreader.h"
+#include "baldr/nodeinfo.h"
+#include "baldr/directededge.h"
+#include "baldr/merge.h"
+
+namespace vb = valhalla::baldr;
+
+namespace {
+
+struct graph_tile_builder {
+  void add_tile(vb::GraphId id) {
+    const size_t nodes_size = nodes.size() * sizeof(vb::NodeInfo);
+    const size_t edges_size = edges.size() * sizeof(vb::DirectedEdge);
+
+    std::vector<char> mem(sizeof(vb::GraphTileHeader) + nodes_size + edges_size);
+    char *ptr = reinterpret_cast<char *>(mem.data());
+
+    vb::GraphTileHeader *header = new(ptr) vb::GraphTileHeader;
+    header->set_graphid(id);
+    header->set_nodecount(nodes.size());
+    header->set_directededgecount(edges.size());
+
+    ptr += sizeof(vb::GraphTileHeader);
+    memcpy(ptr, nodes.data(), nodes_size);
+    ptr += nodes_size;
+    memcpy(ptr, edges.data(), edges_size);
+
+    auto res = memory.emplace(id, std::move(mem));
+    auto &mem2 = res.first->second;
+    tiles.emplace(id, vb::GraphTile(id, mem2.data(), mem2.size()));
+    nodes.clear();
+    edges.clear();
+  }
+
+  std::vector<vb::NodeInfo> nodes;
+  std::vector<vb::DirectedEdge> edges;
+
+  std::unordered_map<vb::GraphId, std::vector<char> > memory;
+  std::unordered_map<vb::GraphId, vb::GraphTile> tiles;
+};
+
+boost::property_tree::ptree read_json(const std::string &json) {
+  boost::property_tree::ptree p;
+  std::istringstream istr(json);
+  boost::property_tree::json_parser::read_json(istr, p);
+  return p;
+}
+
+const boost::property_tree::ptree fake_config =
+  read_json("{\"tile_dir\": \"/file/does/not/exist\"}");
+
+struct test_graph_reader : public vb::GraphReader {
+  test_graph_reader(std::unordered_map<vb::GraphId, vb::GraphTile> &&tiles)
+    : GraphReader(fake_config) {
+    cache_ = std::move(tiles);
+  }
+};
+
+void TestCollapseEdge() {
+  vb::TileHierarchy hier("");
+  vb::GraphId base_id = hier.GetGraphId(valhalla::midgard::PointLL(0, 0), 0);
+
+  // simplest graph with a collapsible node:
+  //
+  //          /---(edge 0)-->\       /---(edge 1)-->\
+  //  (node 0)                (node 1)              (node 2)
+  //          \<--(edge 2)---/       \<--(edge 3)---/
+  //
+  graph_tile_builder builder;
+  builder.nodes.push_back(
+    vb::NodeInfo(
+      std::make_pair(0.00f, 0.0f),
+      vb::RoadClass::kResidential,
+      vb::kAllAccess,
+      vb::NodeType::kStreetIntersection,
+      false));
+  builder.nodes.back().set_edge_count(1);
+  builder.nodes.back().set_edge_index(0);
+
+  builder.nodes.push_back(
+    vb::NodeInfo(
+      std::make_pair(0.01f, 0.0f),
+      vb::RoadClass::kResidential,
+      vb::kAllAccess,
+      vb::NodeType::kStreetIntersection,
+      false));
+  builder.nodes.back().set_edge_count(2);
+  builder.nodes.back().set_edge_index(1);
+
+  builder.nodes.push_back(
+    vb::NodeInfo(
+      std::make_pair(0.02f, 0.0f),
+      vb::RoadClass::kResidential,
+      vb::kAllAccess,
+      vb::NodeType::kStreetIntersection,
+      false));
+  builder.nodes.back().set_edge_count(1);
+  builder.nodes.back().set_edge_index(3);
+
+  builder.edges.emplace_back();
+  builder.edges.back().set_endnode(base_id + uint64_t(1));
+  builder.edges.back().set_length(1113);
+  builder.edges.back().set_forwardaccess(vb::kAllAccess);
+  builder.edges.back().set_reverseaccess(vb::kAllAccess);
+  builder.edges.back().set_classification(vb::RoadClass::kResidential);
+
+  builder.edges.emplace_back();
+  builder.edges.back().set_endnode(base_id + uint64_t(2));
+  builder.edges.back().set_length(1113);
+  builder.edges.back().set_forwardaccess(vb::kAllAccess);
+  builder.edges.back().set_reverseaccess(vb::kAllAccess);
+  builder.edges.back().set_classification(vb::RoadClass::kResidential);
+
+  builder.edges.emplace_back();
+  builder.edges.back().set_endnode(base_id + uint64_t(0));
+  builder.edges.back().set_length(1113);
+  builder.edges.back().set_forwardaccess(vb::kAllAccess);
+  builder.edges.back().set_reverseaccess(vb::kAllAccess);
+  builder.edges.back().set_classification(vb::RoadClass::kResidential);
+
+  builder.edges.emplace_back();
+  builder.edges.back().set_endnode(base_id + uint64_t(1));
+  builder.edges.back().set_length(1113);
+  builder.edges.back().set_forwardaccess(vb::kAllAccess);
+  builder.edges.back().set_reverseaccess(vb::kAllAccess);
+  builder.edges.back().set_classification(vb::RoadClass::kResidential);
+
+  builder.add_tile(base_id);
+  assert(builder.tiles.size() == 1);
+
+  test_graph_reader reader(std::move(builder.tiles));
+
+  size_t count = 0;
+  std::set<vb::GraphId> edges;
+  for (uint64_t i = 0; i < 4; ++i) {
+    edges.insert(base_id + i);
+  }
+
+  vb::merge::merge(reader, [&](const vb::merge::path &p) {
+      count += 1;
+      for (auto id : p.m_edges) {
+        if (edges.count(id) != 1) {
+          throw std::runtime_error("Edge not found - either invalid or duplicate!");
+        }
+        edges.erase(id);
+      }
+    });
+
+  if (count != 2) {
+    throw std::runtime_error("Should have collapsed to 2 paths.");
+  }
+  if (!edges.empty()) {
+    throw std::runtime_error("Some edges left over!");
+  }
+}
+
+} // anonymous namespace
+
+int main() {
+  test::suite suite("edgecollapser");
+
+  suite.test(TEST_CASE(TestCollapseEdge));
+
+  return suite.tear_down();
+}

--- a/test/edgecollapser.cc
+++ b/test/edgecollapser.cc
@@ -110,7 +110,10 @@ void TestCollapseEdgeSimple() {
     edges.insert(base_id + i);
   }
 
-  vb::merge::merge(reader, [&](const vb::merge::path &p) {
+  std::vector<vb::GraphId> tiles;
+  tiles.push_back(base_id);
+
+  vb::merge::merge(tiles, reader, [&](const vb::merge::path &p) {
       count += 1;
       for (auto id : p.m_edges) {
         if (edges.count(id) != 1) {
@@ -166,7 +169,10 @@ void TestCollapseEdgeJunction() {
     edges.insert(base_id + i);
   }
 
-  vb::merge::merge(reader, [&](const vb::merge::path &p) {
+  std::vector<vb::GraphId> tiles;
+  tiles.push_back(base_id);
+
+  vb::merge::merge(tiles, reader, [&](const vb::merge::path &p) {
       count += 1;
       for (auto id : p.m_edges) {
         if (edges.count(id) != 1) {

--- a/test/edgecollapser.cc
+++ b/test/edgecollapser.cc
@@ -113,7 +113,10 @@ void TestCollapseEdgeSimple() {
   std::vector<vb::GraphId> tiles;
   tiles.push_back(base_id);
 
-  vb::merge::merge(tiles, reader, [&](const vb::merge::path &p) {
+  vb::merge::merge(
+    tiles, reader,
+    [](const vb::DirectedEdge *) -> bool { return true; },
+    [&](const vb::merge::path &p) {
       count += 1;
       for (auto id : p.m_edges) {
         if (edges.count(id) != 1) {
@@ -172,7 +175,10 @@ void TestCollapseEdgeJunction() {
   std::vector<vb::GraphId> tiles;
   tiles.push_back(base_id);
 
-  vb::merge::merge(tiles, reader, [&](const vb::merge::path &p) {
+  vb::merge::merge(
+    tiles, reader,
+    [](const vb::DirectedEdge *) -> bool { return true; },
+    [&](const vb::merge::path &p) {
       count += 1;
       for (auto id : p.m_edges) {
         if (edges.count(id) != 1) {

--- a/valhalla/baldr/graphid.h
+++ b/valhalla/baldr/graphid.h
@@ -72,6 +72,17 @@ union GraphId {
            const uint32_t id);
 
   /**
+   * Conversion to bool for use in conditional statements.
+   *
+   * Note that this is explicit to avoid unexpected implicit conversions. Some
+   * statements, including "if", "&&", "||", "!" are "implicit explicit" and
+   * will result in conversion.
+   *
+   * @return boolean true if the id is valid.
+   */
+  explicit inline operator bool() const { return Is_Valid(); }
+
+  /**
    * Returns true if the id is valid
    *
    * @return boolean true if the id is valid

--- a/valhalla/baldr/merge.h
+++ b/valhalla/baldr/merge.h
@@ -108,7 +108,7 @@ edge_tracker edge_tracker::create(TileSet &tiles, GraphReader &reader) {
 }
 
 struct edge_collapser {
-  edge_collapser(GraphReader &reader, edge_tracker &tracker, std::function<void(const path &)> func);
+  edge_collapser(GraphReader &reader, edge_tracker &tracker, std::function<bool(const DirectedEdge *)> edge_pred, std::function<void(const path &)> func);
   std::pair<GraphId, GraphId> nodes_reachable_from(GraphId node_id);
   GraphId next_node_id(GraphId last_node_id, GraphId node_id);
   GraphId edge_between(GraphId cur, GraphId next);
@@ -118,6 +118,7 @@ struct edge_collapser {
 private:
   GraphReader &m_reader;
   edge_tracker &m_tracker;
+  std::function<bool(const DirectedEdge *)> m_edge_predictate;
   std::function<void(const path &)> m_func;
 };
 
@@ -134,9 +135,9 @@ path make_single_edge_path(GraphReader &reader, GraphId edge_id);
  * @param func The function to execute for each discovered path.
  */
 template <typename TileSet>
-void merge(TileSet &tiles, GraphReader &reader, std::function<void(const path &)> func) {
+void merge(TileSet &tiles, GraphReader &reader, std::function<bool(const DirectedEdge *)> edge_pred, std::function<void(const path &)> func) {
   detail::edge_tracker tracker = detail::edge_tracker::create(tiles, reader);
-  detail::edge_collapser e(reader, tracker, func);
+  detail::edge_collapser e(reader, tracker, edge_pred, func);
 
   for (GraphId tile_id : tiles) {
     const auto *tile = reader.GetGraphTile(tile_id);

--- a/valhalla/baldr/merge.h
+++ b/valhalla/baldr/merge.h
@@ -31,6 +31,100 @@ struct path {
   void push_front(segment s);
 };
 
+namespace detail {
+
+// a place we can mark what edges we've seen, even for the planet we should
+// need ~ 100mb, as it allocates one bit per ID. there are currently around
+// 453 million ways in OSM, and we might allocate two edge IDs per way,
+// giving something like 108mb of bits needed.
+struct bitset_t {
+  typedef uint64_t value_type;
+  static const size_t bits_per_value = sizeof(value_type) * CHAR_BIT;
+  static const uint64_t u64_size = static_cast<uint64_t>(bits_per_value);
+  static const uint64_t u64_one = static_cast<uint64_t>(1);
+
+  bitset_t(size_t size);
+  void set(const uint64_t id);
+  bool get(const uint64_t id) const;
+
+protected:
+  std::vector<value_type> bits;
+
+  // return ceil(n / q) = r, such that r * q >= n.
+  static inline constexpr size_t div_round_up(size_t n, size_t q) {
+    return (n / q) + ((n % q) ? 1 : 0);
+  }
+
+  // return the "end" id, one greater than the maximum id, supported by this
+  // container.
+  inline uint64_t end_id() const {
+    return static_cast<uint64_t>(bits.size() * bits_per_value);
+  }
+};
+
+// edge tracker wraps a bitset to provide compact storage of GraphIds.
+//
+// the GraphReader is crawled to enumerate all tiles, and the range of tile IDs
+// is used to construct a compact range by concatenating all the existing
+// compact ranges for each tile.
+struct edge_tracker {
+  typedef std::unordered_map<GraphId, uint64_t> edge_index_t;
+
+  template <typename TileSet>
+  static edge_tracker create(TileSet &tiles, GraphReader &reader);
+
+  bool get(const GraphId &edge_id) const;
+  void set(const GraphId &edge_id);
+
+  edge_index_t m_edges_in_tiles;
+  //this is how we know what i've touched and what we havent
+  bitset_t m_edge_set;
+
+private:
+  edge_tracker(edge_index_t &&edges, size_t n)
+    : m_edges_in_tiles(std::move(edges))
+    , m_edge_set(n)
+    {}
+};
+
+template <typename TileSet>
+edge_tracker edge_tracker::create(TileSet &tiles, GraphReader &reader) {
+  //keep the global number of edges encountered at the point we encounter each tile
+  //this allows an edge to have a sequential global id and makes storing it very small
+  uint64_t edge_count = 0;
+  edge_tracker::edge_index_t edges_in_tiles;
+  for (GraphId tile_id : tiles) {
+    //TODO: just read the header, parsing the whole thing isnt worth it at this point
+    edges_in_tiles.emplace(tile_id, edge_count);
+    const auto* tile = reader.GetGraphTile(tile_id);
+    edge_count += tile->header()->directededgecount();
+    // clear the cache if it is overcommitted to avoid running out of memory.
+    if (reader.OverCommitted()) {
+      reader.Clear();
+    }
+  }
+
+  return edge_tracker(std::move(edges_in_tiles), edge_count);
+}
+
+struct edge_collapser {
+  edge_collapser(GraphReader &reader, edge_tracker &tracker, std::function<void(const path &)> func);
+  std::pair<GraphId, GraphId> nodes_reachable_from(GraphId node_id);
+  GraphId next_node_id(GraphId last_node_id, GraphId node_id);
+  GraphId edge_between(GraphId cur, GraphId next);
+  void explore(GraphId node_id);
+  void explore(GraphId prev, GraphId cur, path &forward, path &reverse);
+
+private:
+  GraphReader &m_reader;
+  edge_tracker &m_tracker;
+  std::function<void(const path &)> m_func;
+};
+
+path make_single_edge_path(GraphReader &reader, GraphId edge_id);
+
+} // namespace detail
+
 /**
  * Read the graph and merge all compatible edges, calling the provided function
  * with each path that has been found. Each edge in the graph will be part of
@@ -39,7 +133,32 @@ struct path {
  * @param reader The graph to traverse.
  * @param func The function to execute for each discovered path.
  */
-void merge(GraphReader &reader, std::function<void(const path &)> func);
+template <typename TileSet>
+void merge(TileSet &tiles, GraphReader &reader, std::function<void(const path &)> func) {
+  detail::edge_tracker tracker = detail::edge_tracker::create(tiles, reader);
+  detail::edge_collapser e(reader, tracker, func);
+
+  for (GraphId tile_id : tiles) {
+    const auto *tile = reader.GetGraphTile(tile_id);
+    uint32_t node_count = tile->header()->nodecount();
+    for (uint32_t i = 0; i < node_count; ++i) {
+      GraphId node_id(tile_id.tileid(), tile_id.level(), i);
+      e.explore(node_id);
+    }
+  }
+
+  for (GraphId tile_id : tiles) {
+    const auto *tile = reader.GetGraphTile(tile_id);
+    const auto num_edges = tile->header()->directededgecount();
+    for (uint32_t i = 0; i < num_edges; ++i) {
+      GraphId edge_id(tile_id.tileid(), tile_id.level(), i);
+      if (!tracker.get(edge_id)) {
+        auto p = detail::make_single_edge_path(reader, edge_id);
+        func(p);
+      }
+    }
+  }
+}
 
 }
 }

--- a/valhalla/baldr/merge.h
+++ b/valhalla/baldr/merge.h
@@ -52,7 +52,7 @@ protected:
 
   // return ceil(n / q) = r, such that r * q >= n.
   static inline constexpr size_t div_round_up(size_t n, size_t q) {
-    return (n / q) + ((n % q) ? 1 : 0);
+    return (n + (q - 1)) / q;
   }
 
   // return the "end" id, one greater than the maximum id, supported by this

--- a/valhalla/baldr/merge.h
+++ b/valhalla/baldr/merge.h
@@ -64,7 +64,7 @@ protected:
 
 // edge tracker wraps a bitset to provide compact storage of GraphIds.
 //
-// the GraphReader is crawled to enumerate all tiles, and the range of tile IDs
+// A TileSet is used to enumerate all relevant tiles, and the range of tile IDs
 // is used to construct a compact range by concatenating all the existing
 // compact ranges for each tile.
 struct edge_tracker {
@@ -131,7 +131,9 @@ path make_single_edge_path(GraphReader &reader, GraphId edge_id);
  * with each path that has been found. Each edge in the graph will be part of
  * exactly one path, but paths may contain multiple edges.
  *
+ * @param tiles A range object over GraphId for the tiles to consider.
  * @param reader The graph to traverse.
+ * @param edge_pred A predicate function which should return true for any edge that can be collapsed.
  * @param func The function to execute for each discovered path.
  */
 template <typename TileSet>

--- a/valhalla/baldr/merge.h
+++ b/valhalla/baldr/merge.h
@@ -1,0 +1,44 @@
+#ifndef VALHALLA_BALDR_MERGE_H_
+#define VALHALLA_BALDR_MERGE_H_
+
+#include <valhalla/baldr/graphid.h>
+#include <valhalla/baldr/graphreader.h>
+
+namespace valhalla {
+namespace baldr {
+namespace merge {
+
+struct segment {
+  GraphId m_start, m_edge, m_end;
+  segment(GraphId start, GraphId edge, GraphId end);
+  GraphId start() const { return m_start; }
+  GraphId end() const { return m_end; }
+  GraphId edge() const { return m_edge; }
+};
+
+struct path {
+  GraphId m_start, m_end;
+  std::deque<GraphId> m_edges;
+
+  explicit path(segment s);
+  explicit path(GraphId node_id);
+
+  void push_back(segment s);
+  void push_front(segment s);
+};
+
+/**
+ * Read the graph and merge all compatible edges, calling the provided function
+ * with each path that has been found. Each edge in the graph will be part of
+ * exactly one path, but paths may contain multiple edges.
+ *
+ * @param reader The graph to traverse.
+ * @param func The function to execute for each discovered path.
+ */
+void merge(GraphReader &reader, std::function<void(const path &)> func);
+
+}
+}
+}
+
+#endif  // VALHALLA_BALDR_MERGE_H_

--- a/valhalla/baldr/merge.h
+++ b/valhalla/baldr/merge.h
@@ -8,6 +8,8 @@ namespace valhalla {
 namespace baldr {
 namespace merge {
 
+// a segment is a collection of a start node, end node and the edge between
+// them. this is used when creating paths.
 struct segment {
   GraphId m_start, m_edge, m_end;
   segment(GraphId start, GraphId edge, GraphId end);
@@ -16,6 +18,8 @@ struct segment {
   GraphId edge() const { return m_edge; }
 };
 
+// a path is a start node, end node and a collection of contiguous edges between
+// them. it is created by concatenating segments.
 struct path {
   GraphId m_start, m_end;
   std::deque<GraphId> m_edges;


### PR DESCRIPTION
This adds a function `valhalla::baldr::merge` which takes a `GraphReader` and a functor, and iterates over all the edges in the graph to find those which are collapsible, calling the functor for each collapsed set of edges.

This is a building block for OpenLR-like descriptors, and intended to group edges into sequences where there are no true intersections, but there might be bridges or changes in other properties such as max speed.

@kevinkreiser could you take a look and let me know what you think, please?
