### PR TITLE
Move most "get" methods to .h files. 

### DIFF
--- a/src/baldr/directededge.cc
+++ b/src/baldr/directededge.cc
@@ -56,22 +56,12 @@ DirectedEdge::DirectedEdge() {
   weighted_grade_ = 6;
 }
 
-// Gets the end node of this directed edge.
-GraphId DirectedEdge::endnode() const {
-  return endnode_;
-}
-
 // Sets the end node of this directed edge.
 void DirectedEdge::set_endnode(const GraphId& endnode) {
   endnode_ = endnode;
 }
 
 // ------------------  Data offsets and flags for extended data -------------//
-
-// Get the offset to the common edge information.
-uint64_t DirectedEdge::edgeinfo_offset() const {
-  return edgeinfo_offset_;
-}
 
 // Get the offset to the common edge data.
 void DirectedEdge::set_edgeinfo_offset(const uint32_t offset) {
@@ -84,19 +74,9 @@ void DirectedEdge::set_edgeinfo_offset(const uint32_t offset) {
   }
 }
 
-// Get the general restriction or access condition (per mode) for this directed edge.
-uint64_t DirectedEdge::access_restriction() const {
-  return access_restriction_;
-}
-
 // Set the modes which have access restrictions on this edge.
 void DirectedEdge::set_access_restriction(const uint32_t access) {
   access_restriction_ = access;
-}
-
-// Does this directed edge have exit signs.
-bool DirectedEdge::exitsign() const {
-  return exitsign_;
 }
 
 // Sets the exit flag.
@@ -105,11 +85,6 @@ void DirectedEdge::set_exitsign(const bool exit) {
 }
 
 // ------------------------- Geographic attributes ------------------------- //
-
-// Gets the length of the edge in meters.
-uint32_t DirectedEdge::length() const {
-  return length_;
-}
 
 // Sets the length of the edge in meters.
 void DirectedEdge::set_length(const uint32_t length) {
@@ -121,11 +96,6 @@ void DirectedEdge::set_length(const uint32_t length) {
   }
 }
 
-// Gets the weighted grade factor (0-15).
-uint32_t DirectedEdge::weighted_grade() const {
-  return weighted_grade_;
-}
-
 // Sets the weighted_grade factor (0-15) for the edge.
 void DirectedEdge::set_weighted_grade(const uint32_t factor) {
   if (factor > kMaxGradeFactor) {
@@ -134,11 +104,6 @@ void DirectedEdge::set_weighted_grade(const uint32_t factor) {
   } else {
     weighted_grade_ = factor;
   }
-}
-
-// Get the road curvature factor. (0-15).
-uint32_t DirectedEdge::curvature() const {
-  return curvature_;
 }
 
 // Sets the curvature factor (0-15) for the edge.
@@ -153,21 +118,10 @@ void DirectedEdge::set_curvature(const uint32_t factor) {
 
 // -------------------------- Routing attributes --------------------------- //
 
-// Is driving on the right hand side of the road along this edge?
-bool DirectedEdge::drive_on_right() const {
-  return drive_on_right_;
-}
-
 // Set the flag indicating driving is on the right hand side of the road
 // along this edge?
 void DirectedEdge::set_drive_on_right(const bool rsd) {
   drive_on_right_ = rsd;
-}
-
-// Flag indicating the edge is a dead end (no other driveable
-// roads at the end node of this edge).
-bool DirectedEdge::deadend() const {
-  return deadend_;
 }
 
 // Set the flag indicating the edge is a dead end (no other driveable
@@ -176,30 +130,14 @@ void DirectedEdge::set_deadend(const bool d) {
   deadend_ = d;
 }
 
-// Does this edge have a toll or is it part of a toll road?
-bool DirectedEdge::toll() const {
-  return toll_;
-}
-
 // Sets the flag indicating this edge has a toll or is it part of a toll road.
 void DirectedEdge::set_toll(const bool toll) {
   toll_ = toll;
 }
 
-// Does this edge have a seasonal access (e.g., closed in the winter)?
-bool DirectedEdge::seasonal() const {
-  return seasonal_;
-}
-
 // Sets the flag indicating this edge has seasonal access
 void DirectedEdge::set_seasonal(const bool seasonal) {
   seasonal_ = seasonal;
-}
-
-// Is this edge part of a private or no through road that allows access
-// only if required to get to a destination?
-bool DirectedEdge::destonly() const {
-  return dest_only_;
 }
 
 // Sets the destination only (private) flag. This indicates the edge should
@@ -209,19 +147,9 @@ void DirectedEdge::set_dest_only(const bool destonly) {
   dest_only_ = destonly;
 }
 
-// Is this edge part of a tunnel?
-bool DirectedEdge::tunnel() const {
-  return tunnel_;
-}
-
 // Sets the flag indicating this edge has is a tunnel of part of a tunnel.
 void DirectedEdge::set_tunnel(const bool tunnel) {
   tunnel_ = tunnel;
-}
-
-// Is this edge part of a bridge?
-bool DirectedEdge::bridge() const {
-  return bridge_;
 }
 
 // Sets the flag indicating this edge has is a bridge of part of a bridge.
@@ -229,21 +157,9 @@ void DirectedEdge::set_bridge(const bool bridge) {
   bridge_ = bridge;
 }
 
-// Is this edge part of a roundabout?
-bool DirectedEdge::roundabout() const {
-  return roundabout_;
-}
-
 // Sets the flag indicating the  edge is part of a roundabout.
 void DirectedEdge::set_roundabout(const bool roundabout) {
   roundabout_ = roundabout;
-}
-
-// Is this edge is unreachable by driving. This can happen if a driveable
-// edge is surrounded by pedestrian only edges (e.g. in a city center) or
-// is not properly connected to other edges.
-bool DirectedEdge::unreachable() const {
-  return unreachable_;
 }
 
 // Sets the flag indicating the edge is unreachable by driving. This can
@@ -253,21 +169,10 @@ void DirectedEdge::set_unreachable(const bool unreachable) {
   unreachable_ = unreachable;
 }
 
-// A traffic signal occurs at the end of this edge.
-bool DirectedEdge::traffic_signal() const {
-  return traffic_signal_;
-}
-
 // Sets the flag indicating a traffic signal is present at the end of
 // this edge.
 void DirectedEdge::set_traffic_signal(const bool signal) {
   traffic_signal_ = signal;
-}
-
-// Is this directed edge stored forward in edgeinfo (true) or
-// reverse (false).
-bool DirectedEdge::forward() const {
-  return forward_;
 }
 
 // Set the forward flag. Tells if this directed edge is stored forward
@@ -276,20 +181,9 @@ void DirectedEdge::set_forward(const bool forward) {
   forward_ = forward;
 }
 
-// Does this edge lead into a no-thru region
-bool DirectedEdge::not_thru() const {
-  return not_thru_;
-}
-
 // Sets the not thru flag.
 void DirectedEdge::set_not_thru(const bool not_thru) {
   not_thru_ = not_thru;
-}
-
-// Get the index of the opposing directed edge at the end node of this
-// directed edge.
-uint32_t DirectedEdge::opp_index() const {
-  return opp_index_;
 }
 
 // Set the index of the opposing directed edge at the end node of this
@@ -298,19 +192,9 @@ void DirectedEdge::set_opp_index(const uint32_t opp_index) {
   opp_index_ = opp_index;
 }
 
-// Get the cycle lane type along this edge.
-CycleLane DirectedEdge::cyclelane() const {
-  return static_cast<CycleLane>(cycle_lane_);
-}
-
 // Sets the type of cycle lane (if any) present on this edge.
 void DirectedEdge::set_cyclelane(const CycleLane cyclelane) {
   cycle_lane_ = static_cast<uint32_t>(cyclelane);
-}
-
-// Gets the bike network mask
-uint32_t DirectedEdge::bike_network() const {
-  return bike_network_;
 }
 
 // Sets the bike network mask indicating which (if any) bicycle networks are
@@ -325,19 +209,9 @@ void DirectedEdge::set_bike_network(const uint32_t bike_network) {
   }
 }
 
-// Gets the truck network flag
-bool DirectedEdge::truck_route() const {
-  return truck_route_;
-}
-
 // Sets truck route flag.
 void DirectedEdge::set_truck_route(const bool truck_route) {
   truck_route_ = truck_route;
-}
-
-// Gets the lane count
-uint32_t DirectedEdge::lanecount() const {
-  return lanecount_;
 }
 
 // Sets the number of lanes
@@ -349,13 +223,6 @@ void DirectedEdge::set_lanecount(const uint32_t lanecount) {
   } else {
     lanecount_ = lanecount;
   }
-}
-
-// Get the mask of simple turn restrictions from the end of this directed
-// edge. These are turn restrictions from one edge to another that apply to
-// all vehicles, at all times.
-uint32_t DirectedEdge::restrictions() const {
-  return restrictions_;
 }
 
 // Set simple turn restrictions from the end of this directed edge.
@@ -371,24 +238,9 @@ void DirectedEdge::set_restrictions(const uint32_t mask) {
   }
 }
 
-// Get the use type of this edge.
-Use DirectedEdge::use() const {
-  return static_cast<Use>(use_);
-}
-
-// Is this edge a transit line (bus or rail)?
-bool DirectedEdge::IsTransitLine() const {
-  return (use() == Use::kRail || use() == Use::kBus);
-}
-
 // Sets the specialized use type of this edge.
 void DirectedEdge::set_use(const Use use) {
   use_ = static_cast<uint32_t>(use);
-}
-
-// Get the speed type (see graphconstants.h)
-SpeedType DirectedEdge::speed_type() const {
-  return static_cast<SpeedType>(speed_type_);
 }
 
 // Set the speed type (see graphconstants.h)
@@ -396,19 +248,9 @@ void DirectedEdge::set_speed_type(const SpeedType speed_type) {
   speed_type_ = static_cast<uint32_t>(speed_type);
 }
 
-// Get the country crossing flag.
-bool DirectedEdge::ctry_crossing() const {
-  return ctry_crossing_;
-}
-
 // Set the country crossing flag.
 void DirectedEdge::set_ctry_crossing(const bool crossing) {
   ctry_crossing_ = crossing;
-}
-
-// Get the access modes in the forward direction (bit field).
-uint32_t DirectedEdge::forwardaccess() const {
-  return forwardaccess_;
 }
 
 // Set the access modes in the forward direction (bit field).
@@ -430,11 +272,6 @@ void DirectedEdge::set_all_forward_access() {
   reverseaccess_ = kAllAccess;
 }
 
-// Get the access modes in the reverse direction (bit field).
-uint32_t DirectedEdge::reverseaccess() const {
-  return reverseaccess_;
-}
-
 // Set the access modes in the reverse direction (bit field).
 void DirectedEdge::set_reverseaccess(const uint32_t modes) {
   if (modes > kAllAccess) {
@@ -448,11 +285,6 @@ void DirectedEdge::set_reverseaccess(const uint32_t modes) {
 
 // -------------------------------- speed -------------------------- //
 
-// Gets the average speed in KPH.
-uint32_t DirectedEdge::speed() const {
-  return speed_;
-}
-
 // Sets the average speed in KPH.
 void DirectedEdge::set_speed(const uint32_t speed) {
   if (speed > kMaxSpeed) {
@@ -463,11 +295,6 @@ void DirectedEdge::set_speed(const uint32_t speed) {
   }
 }
 
-// Gets the speed limit in KPH.
-uint32_t DirectedEdge::speed_limit() const {
-  return speed_limit_;
-}
-
 // Sets the speed limit in KPH.
 void DirectedEdge::set_speed_limit(const uint32_t speed_limit) {
   if (speed_limit > kMaxSpeed) {
@@ -476,11 +303,6 @@ void DirectedEdge::set_speed_limit(const uint32_t speed_limit) {
   } else {
     speed_limit_ = speed_limit;
   }
-}
-
-// Gets the truck speed in KPH.
-uint32_t DirectedEdge::truck_speed() const {
-  return truck_speed_;
 }
 
 // Sets the truck speed in KPH.
@@ -494,24 +316,10 @@ void DirectedEdge::set_truck_speed(const uint32_t speed) {
 }
 
 // ----------------------------- Classification ---------------------------- //
-// Get the road classification.
-RoadClass DirectedEdge::classification() const {
-  return static_cast<RoadClass>(classification_);
-}
 
 // Sets the classification (importance) of this edge.
 void DirectedEdge::set_classification(const RoadClass roadclass) {
   classification_= static_cast<uint32_t>(roadclass);
-}
-
-// Is the edge considered unpaved?
-bool DirectedEdge::unpaved() const {
-  return (surface() >= Surface::kCompacted);
-}
-
-// Get the smoothness of this edge.
-Surface DirectedEdge::surface() const {
-  return static_cast<Surface>(surface_);
 }
 
 // Sets the surface type (see baldr/graphconstants.h). This is a general
@@ -520,20 +328,10 @@ void DirectedEdge::set_surface(const Surface surface) {
   surface_ = static_cast<uint32_t>(surface);
 }
 
-// Is this edge a link / ramp?
-bool DirectedEdge::link() const {
-  return link_;
-}
-
 // Sets the link flag indicating the edge is part of a link or connection
 // (ramp or turn channel).
 void DirectedEdge::set_link(const bool link) {
   link_ = link;
-}
-
-// Gets the intersection internal flag.
-bool DirectedEdge::internal() const {
-  return internal_;
 }
 
 // Sets the intersection internal flag.
@@ -541,29 +339,14 @@ void DirectedEdge::set_internal(const bool internal) {
   internal_ = internal;
 }
 
-// Get the Complex restriction (per mode) for this directed edge at the start.
-uint32_t DirectedEdge::start_restriction() const {
-  return start_restriction_;
-}
-
 // Set the Complex restriction (per mode) for this directed edge at the start.
 void DirectedEdge::set_start_restriction(const uint32_t modes) {
   start_restriction_ = modes;
 }
 
-// Get the Complex restriction (per mode) for this directed edge at the end.
-uint32_t DirectedEdge::end_restriction() const {
-  return end_restriction_;
-}
-
 // Set the Complex restriction (per mode) for this directed edge at the end.
 void DirectedEdge::set_end_restriction(const uint32_t modes) {
   end_restriction_ = modes;
-}
-
-// Is this part of complex restriction flag.
-bool DirectedEdge::part_of_complex_restriction() const {
-  return part_of_complex_restriction_;
 }
 
 // Set the part of complex restriction flag.
@@ -611,11 +394,6 @@ void DirectedEdge::set_max_down_slope(const float slope) {
   }
 }
 
-// Get the density along the edges.
-uint32_t DirectedEdge::density() const {
-  return density_;
-}
-
 // Set the density along the edges.
 void DirectedEdge::set_density(const uint32_t density) {
   if (density > kMaxDensity) {
@@ -626,32 +404,14 @@ void DirectedEdge::set_density(const uint32_t density) {
   }
 }
 
-// Is there a sidewalk to the left of this directed edge?
-bool DirectedEdge::sidewalk_left() const {
-  return sidewalk_left_;
-}
-
 // Set the flag for a sidewalk to the left of this directed edge.
 void DirectedEdge::set_sidewalk_left(const bool sidewalk) {
   sidewalk_left_ = sidewalk;
 }
 
-// Is there a sidewalk to the right of this directed edge?
-bool DirectedEdge::sidewalk_right() const {
-  return sidewalk_right_;
-}
-
 // Set the flag for a sidewalk to the right of this directed edge.
 void DirectedEdge::set_sidewalk_right(const bool sidewalk) {
   sidewalk_right_ = sidewalk;
-}
-
-// Gets the turn type given the prior edge's local index
-Turn::Type DirectedEdge::turntype(const uint32_t localidx) const {
-  // Turn type is 3 bits per index
-  uint32_t shift = localidx * 3;
-  return static_cast<Turn::Type>(
-      ((turntype_ & (7 << shift))) >> shift);
 }
 
 // Sets the turn type given the prior edge's local index
@@ -666,11 +426,6 @@ void DirectedEdge::set_turntype(const uint32_t localidx,
   }
 }
 
-// Is there an edge to the left, in between the from edge and this edge.
-bool DirectedEdge::edge_to_left(const uint32_t localidx) const {
-  return (edge_to_left_ & (1 << localidx));
-}
-
 // Set the flag indicating there is an edge to the left, in between
 // the from edge and this edge.
 void DirectedEdge::set_edge_to_left(const uint32_t localidx,
@@ -680,14 +435,6 @@ void DirectedEdge::set_edge_to_left(const uint32_t localidx,
   } else {
     edge_to_left_ = OverwriteBits(edge_to_left_, left, localidx, 1);
   }
-}
-
-// Get the stop impact when transitioning from the prior edge (given
-// by the local index of the corresponding inbound edge at the node).
-uint32_t DirectedEdge::stopimpact(const uint32_t localidx) const {
-  // Stop impact is 3 bits per index
-  uint32_t shift = localidx * 3;
-  return (stopimpact_.s.stopimpact & (7 << shift)) >> shift;
 }
 
 // Set the stop impact when transitioning from the prior edge (given
@@ -704,19 +451,9 @@ void DirectedEdge::set_stopimpact(const uint32_t localidx,
   }
 }
 
-// Get the transit line Id (for departure lookups along an edge)
-uint32_t DirectedEdge::lineid() const {
-  return stopimpact_.lineid;
-}
-
 // Set the unique transit line Id.
 void DirectedEdge::set_lineid(const uint32_t lineid) {
   stopimpact_.lineid = lineid;
-}
-
-// Is there an edge to the right, in between the from edge and this edge.
-bool DirectedEdge::edge_to_right(const uint32_t localidx) const {
-  return (stopimpact_.s.edge_to_right & (1 << localidx));
 }
 
 // Set the flag indicating there is an edge to the right, in between
@@ -731,13 +468,6 @@ void DirectedEdge::set_edge_to_right(const uint32_t localidx,
   }
 }
 
-// Get the index of the directed edge on the local level of the graph
-// hierarchy. This is used for turn restrictions so the edges can be
-// identified on the different levels.
-uint32_t DirectedEdge::localedgeidx() const {
-  return localedgeidx_;
-}
-
 // Set the index of the directed edge on the local level of the graph
 // hierarchy. This is used for turn restrictions so the edges can be
 // identified on the different levels.
@@ -750,13 +480,6 @@ void DirectedEdge::set_localedgeidx(const uint32_t idx) {
   }
 }
 
-// Get the index of the opposing directed edge on the local hierarchy level
-// at the end node of this directed edge. Only stored for the first 8 edges
-// so it can be used for edge transition costing.
-uint32_t DirectedEdge::opp_local_idx() const {
-  return opp_local_idx_;
-}
-
 // Set the index of the opposing directed edge on the local hierarchy level
 // at the end node of this directed edge. Only stored for the first 8 edges
 // so it can be used for edge transition costing.
@@ -767,12 +490,6 @@ void DirectedEdge::set_opp_local_idx(const uint32_t idx) {
   } else {
     opp_local_idx_ = idx;
   }
-}
-
-// Get the shortcut mask indicating the edge index that is superseded by
-// this shortcut (0 if not a shortcut)
-uint32_t DirectedEdge::shortcut() const {
- return shortcut_;
 }
 
 // Set the flag for whether this edge represents a shortcut between 2 nodes.
@@ -792,12 +509,6 @@ void DirectedEdge::set_shortcut(const uint32_t shortcut) {
   is_shortcut_ = true;
 }
 
-// Get the mask of the shortcut edge that supersedes this edge. 0 indicates
-// no shortcut edge supersedes this edge.
-uint32_t DirectedEdge::superseded() const {
-  return superseded_;
-}
-
 // Set the flag for whether this edge is superseded by a shortcut edge.
 void DirectedEdge::set_superseded(const uint32_t superseded) {
   if (superseded > kMaxShortcutsFromNode) {
@@ -807,38 +518,16 @@ void DirectedEdge::set_superseded(const uint32_t superseded) {
   }
 }
 
-// Does this edge represent a transition up one level in the hierarchy.
-bool DirectedEdge::trans_up() const {
-  return (use() == Use::kTransitionUp);
-}
-
-
 // Set the use indicating this edge represents a transition up one level
 // in the hierarchy.
 void DirectedEdge::set_trans_up() {
   set_use(Use::kTransitionUp);
 }
 
-// Does this edge represent a transition down one level in the hierarchy.
-bool DirectedEdge::trans_down() const {
-  return (use() == Use::kTransitionDown);
-}
-
-
 // Set the use indicating this edge represents a transition down one level
 // in the hierarchy.
 void DirectedEdge::set_trans_down() {
   set_use(Use::kTransitionDown);
-}
-
-// Is this directed edge a shortcut?
-bool DirectedEdge::is_shortcut() const {
-  return is_shortcut_;
-}
-
-// Does this directed edge end in a different tile.
-bool DirectedEdge::leaves_tile() const {
-  return leaves_tile_;
 }
 
 // Set the flag indicating whether the end node of this directed edge is in

--- a/src/baldr/double_bucket_queue.cc
+++ b/src/baldr/double_bucket_queue.cc
@@ -49,14 +49,6 @@ void DoubleBucketQueue::clear() {
   currentbucket_ = buckets_.begin();
 }
 
-// Adds a label index to the bucketed sort. Adds it to the appropriate bucket
-// given the cost. If the cost is greater than maxcost_ the label
-// is placed in the overflow bucket. If the cost is < the current bucket
-// cost then the label is placed in the current bucket to prevent underflow.
-void DoubleBucketQueue::add(const uint32_t label, const float cost) {
-  get_bucket(cost).push_back(label);
-}
-
 // The specified label now has a smaller cost.  Reorders it in the sorted list
 void DoubleBucketQueue::decrease(const uint32_t label, const float newcost,
                                  const float previouscost) {
@@ -112,17 +104,6 @@ uint32_t DoubleBucketQueue::pop() {
     }
   }
   return kInvalidLabel;
-}
-
-// Returns the bucket given the cost
-std::deque<uint32_t>& DoubleBucketQueue::get_bucket(const float cost) {
-  if (cost < currentcost_) {
-    return *currentbucket_;
-  } else {
-    return (cost < maxcost_) ?
-        buckets_[static_cast<uint32_t>((cost - mincost_) * inv_)] :
-        overflowbucket_;
-  }
 }
 
 // Empties the overflow bucket by placing the labels into the

--- a/src/baldr/graphid.cc
+++ b/src/baldr/graphid.cc
@@ -3,41 +3,13 @@
 #include "baldr/graphid.h"
 #include "baldr/graphconstants.h"
 
-namespace {
-// Invalid graphid.
-constexpr uint32_t kInvalidId = std::numeric_limits<uint32_t>::max();
-}
-
 namespace valhalla {
 namespace baldr {
-
-// Default constructor
-GraphId::GraphId() {
-  value = kInvalidId;
-}
 
 // Constructor with values for each field of the GraphId.
 GraphId::GraphId(const uint32_t tileid, const uint32_t level,
                  const uint32_t id) {
   Set(tileid, level, id);
-}
-
-GraphId::GraphId(const uint64_t value): value(value){
-}
-
-// Get the tile Id
-uint32_t GraphId::tileid() const {
-  return fields.tileid;
-}
-
-// Get the hierarchy level
-uint32_t GraphId::level() const {
-  return fields.level;
-}
-
-// Get the Id
-uint32_t GraphId::id() const {
-  return fields.id;
 }
 
 // Set the fields of the GraphId
@@ -52,14 +24,7 @@ void GraphId::Set(const uint32_t tileid, const uint32_t level,
   fields.spare = 0;
 }
 
-bool GraphId::Is_Valid() const {
-  return value != kInvalidId;
-}
-
-GraphId GraphId::Tile_Base() const {
-  return GraphId( fields.tileid,  fields.level, 0);
-}
-
+// The json representation of the Id
 json::Value GraphId::json() const {
   if(Is_Valid())
     return json::map({
@@ -70,37 +35,9 @@ json::Value GraphId::json() const {
   return static_cast<std::nullptr_t>(nullptr);
 }
 
-// Post increments the id.
-void GraphId::operator ++(int) {
-  fields.id++;
-}
-
-// Advance the id.
-GraphId GraphId::operator+(uint64_t offset) const {
-  return GraphId(fields.tileid, fields.level, fields.id + offset);
-}
-
-// Comparison for sorting
-bool GraphId::operator <(const GraphId& rhs) const {
-  return value < rhs.value;
-}
-
-// Equality operator
-bool GraphId::operator ==(const GraphId& rhs) const {
-  return value == rhs.value;
-}
-
-bool GraphId::operator !=(const GraphId& rhs) const {
-  return value != rhs.value;
-}
-
-GraphId::operator uint64_t() const {
-  return value;
-}
-
-std::ostream& operator<<(std::ostream& os, const GraphId& id)
-{
-    return os << id.fields.level << '/' << id.fields.tileid << '/' << id.fields.id;
+// Stream output
+std::ostream& operator<<(std::ostream& os, const GraphId& id) {
+  return os << id.fields.level << '/' << id.fields.tileid << '/' << id.fields.id;
 }
 
 }

--- a/src/baldr/graphtileheader.cc
+++ b/src/baldr/graphtileheader.cc
@@ -284,12 +284,15 @@ std::pair<uint32_t, uint32_t> GraphTileHeader::bin_offset(size_t index) const {
 
 // Gets the offset to the end of the tile.
 uint32_t GraphTileHeader::end_offset() const {
-  return end_offset_;
+  return empty_slots_[0];
 }
 
-// Sets the offset to the end of the tile.
+// Sets the offset to the end of the tile. Fills all empty slots with the
+// offset value. This allows compatibility with different tile versions.
 void GraphTileHeader::set_end_offset(uint32_t offset) {
-  end_offset_ = offset;
+  for (size_t i = 0; i < kEmptySlots; i++) {
+    empty_slots_[i] = offset;
+  }
 }
 
 }

--- a/src/baldr/nodeinfo.cc
+++ b/src/baldr/nodeinfo.cc
@@ -84,19 +84,9 @@ NodeInfo::NodeInfo(const std::pair<float, float>& ll,
   set_traffic_signal(traffic_signal);
 }
 
-// Get the latitude, longitude
-const PointLL& NodeInfo::latlng() const {
-  return static_cast<const PointLL&>(latlng_);
-}
-
 // Sets the latitude and longitude.
 void NodeInfo::set_latlng(const std::pair<float, float>& ll) {
   latlng_ = ll;
-}
-
-// Get the index in this tile of the first outbound directed edge
-uint32_t NodeInfo::edge_index() const {
-  return edge_index_;
 }
 
 // Set the index in the node's tile of its first outbound edge.
@@ -106,11 +96,6 @@ void NodeInfo::set_edge_index(const uint32_t edge_index) {
     throw std::runtime_error("NodeInfo: edge index exceeds max");
   }
   edge_index_ = edge_index;
-}
-
-// Get the number of outbound edges from this node.
-uint32_t NodeInfo::edge_count() const {
-  return edge_count_;
 }
 
 // Set the number of outbound directed edges.
@@ -125,12 +110,6 @@ void NodeInfo::set_edge_count(const uint32_t edge_count) {
   }
 }
 
-// Get the access modes (bit mask) allowed to pass through the node.
-// See graphconstants.h
-uint16_t NodeInfo::access() const {
-  return access_;
-}
-
 // Set the access modes (bit mask) allowed to pass through the node.
 void NodeInfo::set_access(const uint32_t access) {
   if (access > kAllAccess) {
@@ -142,19 +121,9 @@ void NodeInfo::set_access(const uint32_t access) {
   }
 }
 
-// Get the intersection type.
-IntersectionType NodeInfo::intersection() const {
-  return static_cast<IntersectionType>(intersection_);
-}
-
 // Set the intersection type.
 void NodeInfo::set_intersection(const IntersectionType type) {
   intersection_ = static_cast<uint32_t>(type);
-}
-
-// Get the index of the administrative information within this tile.
-uint32_t NodeInfo::admin_index() const {
-  return admin_index_;
 }
 
 // Set the index of the administrative information within this tile.
@@ -169,11 +138,6 @@ void NodeInfo::set_admin_index(const uint16_t admin_index) {
   }
 }
 
-// Returns the timezone index.
-uint32_t NodeInfo::timezone() const {
-  return timezone_;
-}
-
 // Set the timezone index.
 void NodeInfo::set_timezone(const uint32_t timezone) {
   if (timezone > kMaxTimeZonesPerTile) {
@@ -184,13 +148,6 @@ void NodeInfo::set_timezone(const uint32_t timezone) {
   } else {
     timezone_ = timezone;
   }
-}
-
-// Get the driveability of the local directed edge given a local
-// edge index.
-Traversability NodeInfo::local_driveability(const uint32_t localidx) const {
-  uint32_t s = localidx * 2;     // 2 bits per index
-  return static_cast<Traversability>((local_driveability_ & (3 << s)) >> s);
 }
 
 // Set the driveability of the local directed edge given a local
@@ -205,11 +162,6 @@ void NodeInfo::set_local_driveability(const uint32_t localidx,
   }
 }
 
-// Get the relative density at the node.
-uint32_t NodeInfo::density() const {
-  return density_;
-}
-
 // Set the relative density
 void NodeInfo::set_density(const uint32_t density) {
   if (density > kMaxDensity) {
@@ -220,25 +172,9 @@ void NodeInfo::set_density(const uint32_t density) {
   }
 }
 
-// Gets the node type. See graphconstants.h for the list of types.
-NodeType NodeInfo::type() const {
-  return static_cast<NodeType>(type_);
-}
-
 // Set the node type.
 void NodeInfo::set_type(const NodeType type) {
   type_ = static_cast<uint32_t>(type);
-}
-
-// Checks if this node is a transit node.
-bool NodeInfo::is_transit() const {
-  return type() == NodeType::kMultiUseTransitStop;
-}
-
-// Get the number of edges on the local level. We add 1 to allow up to
-// up to kMaxLocalEdgeIndex + 1.
-uint32_t NodeInfo::local_edge_count() const {
-  return local_edge_count_ + 1;
 }
 
 // Set the number of driveable edges on the local level. Subtract 1 so
@@ -254,13 +190,6 @@ void NodeInfo::set_local_edge_count(const uint32_t n) {
   }
 }
 
-// Is a mode change allowed at this node? The access data tells which
-// modes are allowed at the node. Examples include transit stops, bike
-// share locations, and parking locations.
-bool NodeInfo::mode_change() const {
-  return mode_change_;
-}
-
 // Sets the flag indicating a mode change is allowed at this node.
 // The access data tells which modes are allowed at the node. Examples
 // include transit stops, bike share locations, and parking locations.
@@ -268,20 +197,9 @@ void NodeInfo::set_mode_change(const bool mc) {
   mode_change_ = mc;
 }
 
-// Is there a traffic signal at this node?
-bool NodeInfo::traffic_signal() const {
-  return traffic_signal_;
-}
-
 // Set the traffic signal flag.
 void NodeInfo::set_traffic_signal(const bool traffic_signal) {
   traffic_signal_ = traffic_signal;
-}
-
-// Gets the transit stop index. This is used for schedule lookups
-// and possibly queries to a transit service.
-uint32_t NodeInfo::stop_index() const {
-  return stop_.stop_index;
 }
 
 // Set the transit stop index.

--- a/src/baldr/tilehierarchy.cc
+++ b/src/baldr/tilehierarchy.cc
@@ -41,7 +41,7 @@ uint8_t TileHierarchy::get_level(const RoadClass roadclass) const {
     return 1;
   } else {
     return 2;
-  };
+  }
 }
 
 }

--- a/valhalla/baldr/directededge.h
+++ b/valhalla/baldr/directededge.h
@@ -23,7 +23,9 @@ class DirectedEdge {
    * Gets the end node of this directed edge.
    * @return  Returns the end node.
    */
-  GraphId endnode() const;
+  GraphId endnode() const {
+    return endnode_;
+  };
 
   /**
    * Set the end node of this directed edge.
@@ -36,7 +38,9 @@ class DirectedEdge {
    * of the common edge information  within a tile.
    * @return  Returns offset from the start of the edge info within a tile.
    */
-  uint64_t edgeinfo_offset() const;
+  uint64_t edgeinfo_offset() const {
+    return edgeinfo_offset_;
+  }
 
   /**
    * Set the offset to the common edge info. The offset is from the start
@@ -49,7 +53,9 @@ class DirectedEdge {
    * General restriction or access condition (per mode) for this directed edge.
    * @return  Returns the restriction for the directed edge.
    */
-  uint64_t access_restriction() const;
+  uint64_t access_restriction() const {
+    return access_restriction_;
+  }
 
   /**
    * Set the modes which have access restrictions on this edge.
@@ -62,7 +68,9 @@ class DirectedEdge {
    * @return  Returns true if the directed edge has exit signs,
    *          false if not.
    */
-  bool exitsign() const;
+  bool exitsign() const {
+    return exitsign_;
+  }
 
   /**
    * Sets the exit sign flag.
@@ -74,7 +82,9 @@ class DirectedEdge {
    * Gets the length of the edge in meters.
    * @return  Returns the length in meters.
    */
-  uint32_t length() const;
+  uint32_t length() const {
+    return length_;
+  }
 
   /**
    * Sets the length of the edge in meters.
@@ -87,7 +97,9 @@ class DirectedEdge {
    * @return  Returns the weighted grade factor (0-15).
    *          where 0 is a 10% grade and 15 is 15%
    */
-  uint32_t weighted_grade() const;
+  uint32_t weighted_grade() const {
+    return weighted_grade_;
+  }
 
   /**
    * Sets the weighted grade factor (0-15) for the edge.
@@ -99,7 +111,9 @@ class DirectedEdge {
    * Get the road curvature factor. TODO
    * @return  Returns the curvature factor (0-15).
    */
-  uint32_t curvature() const;
+  uint32_t curvature() const {
+    return curvature_;
+  }
 
   /**
    * Sets the curvature factor (0-16) for the edge. TODO.
@@ -112,7 +126,9 @@ class DirectedEdge {
    * @return  Returns true if this edge uses right-side driving, false if
    *          left-side driving.
    */
-  bool drive_on_right() const;
+  bool drive_on_right() const {
+    return drive_on_right_;
+  }
 
   /**
    * Set the flag indicating driving is on the right hand side of the road
@@ -127,7 +143,9 @@ class DirectedEdge {
    * roads at the end node of this edge).
    * @return  Returns true if this edge is a dead end.
    */
-  bool deadend() const;
+  bool deadend() const {
+    return deadend_;
+  }
 
   /**
    * Set the flag indicating the edge is a dead end (no other driveable
@@ -140,7 +158,9 @@ class DirectedEdge {
    * Does this edge have a toll or is it part of a toll road?
    * @return  Returns true if this edge is part of a toll road, false if not.
    */
-  bool toll() const;
+  bool toll() const {
+    return toll_;
+  }
 
   /**
    * Sets the flag indicating this edge has a toll or is it part of
@@ -153,7 +173,9 @@ class DirectedEdge {
    * Does this edge have a seasonal access (e.g., closed in the winter)?
    * @return  Returns true if this edge has seasonal access, false if not.
    */
-  bool seasonal() const;
+  bool seasonal() const {
+    return seasonal_;
+  }
 
   /**
    * Sets the flag indicating this edge has seasonal access.
@@ -166,7 +188,9 @@ class DirectedEdge {
    * only if required to get to a destination?
    * @return  Returns true if the edge is destination only / private access.
    */
-  bool destonly() const;
+  bool destonly() const {
+    return dest_only_;
+  }
 
   /**
    * Sets the destination only (private) flag. This indicates the edge should
@@ -181,7 +205,9 @@ class DirectedEdge {
    * Is this edge part of a tunnel?
    * @return  Returns true if this edge is part of a tunnel, false if not.
    */
-  bool tunnel() const;
+  bool tunnel() const  {
+    return tunnel_;
+  }
 
   /**
    * Sets the flag indicating this edge has is a tunnel of part of a tunnel.
@@ -193,7 +219,9 @@ class DirectedEdge {
    * Is this edge part of a bridge?
    * @return  Returns true if this edge is part of a bridge, false if not.
    */
-  bool bridge() const;
+  bool bridge() const {
+    return bridge_;
+  }
 
   /**
    * Sets the flag indicating this edge has is a bridge of part of a bridge.
@@ -205,7 +233,9 @@ class DirectedEdge {
    * Is this edge part of a roundabout?
    * @return  Returns true if this edge is part of a roundabout, false if not.
    */
-  bool roundabout() const;
+  bool roundabout() const {
+    return roundabout_;
+  }
 
   /**
    * Sets the flag indicating the edge is part of a roundabout.
@@ -219,7 +249,9 @@ class DirectedEdge {
    * is not properly connected to other edges.
    * @return  Returns true if this edge is unreachable by auto.
    */
-  bool unreachable() const;
+  bool unreachable() const {
+    return unreachable_;
+  }
 
   /**
    * Sets the flag indicating the edge is unreachable by driving. This can
@@ -235,7 +267,9 @@ class DirectedEdge {
    * @return  Returns true if a traffic signal is present at the end of the
    *          directed edge.
    */
-  bool traffic_signal() const;
+  bool traffic_signal() const  {
+    return traffic_signal_;
+  }
 
   /**
    * Sets the flag indicating a traffic signal is present at the end of
@@ -250,7 +284,9 @@ class DirectedEdge {
    * reverse (false).
    * @return  Returns true if stored forward, false if reverse.
    */
-  bool forward() const;
+  bool forward() const {
+    return forward_;
+  }
 
   /**
    * Set the forward flag. Tells if this directed edge is stored forward
@@ -265,7 +301,9 @@ class DirectedEdge {
    * identify such edges. This is used to speed pedestrian routing.
    * @return  Returns true if the edge leads into a no thru region.
    */
-  bool not_thru() const;
+  bool not_thru() const {
+    return not_thru_;
+  }
 
   /**
    * Set the not_thru flag. If an edge leads to a "no thru" region where
@@ -281,7 +319,9 @@ class DirectedEdge {
    * @return  Returns the index of the opposing directed edge at the end node
    *          of this directed edge.
    */
-  uint32_t opp_index() const;
+  uint32_t opp_index() const {
+    return opp_index_;
+  }
 
   /**
    * Set the index of the opposing directed edge at the end node of this
@@ -294,7 +334,9 @@ class DirectedEdge {
    * Get the cycle lane type along this edge.
    * @returns   Returns the type (if any) of bicycle lane along this edge.
    */
-  CycleLane cyclelane() const;
+  CycleLane cyclelane() const  {
+    return static_cast<CycleLane>(cycle_lane_);
+  }
 
   /**
    * Sets the type of cycle lane (if any) present on this edge.
@@ -306,7 +348,9 @@ class DirectedEdge {
    * Get the bike network mask for this directed edge.
    * @return  Returns the bike network mask for this directed edge.
    */
-  uint32_t bike_network() const;
+  uint32_t bike_network() const {
+    return bike_network_;
+  }
 
   /**
    * Sets the bike network mask indicating which (if any) bicycle networks are
@@ -319,7 +363,9 @@ class DirectedEdge {
    * Get the truck route flag for this directed edge.
    * @return  Returns true if part of a truck network/route, false otherwise.
    */
-  bool truck_route() const;
+  bool truck_route() const {
+    return truck_route_;
+  }
 
   /**
    * Set the truck route flag for this directed edge.
@@ -331,7 +377,9 @@ class DirectedEdge {
    * Get the number of lanes for this directed edge.
    * @return  Returns the number of lanes for this directed edge.
    */
-  uint32_t lanecount() const;
+  uint32_t lanecount() const {
+    return lanecount_;
+  }
 
   /**
    * Sets the number of lanes
@@ -346,7 +394,9 @@ class DirectedEdge {
    * @return  Returns a bit mask that indicates the local edge indexes
    *          of outbound directed edges that are restricted.
    */
-  uint32_t restrictions() const;
+  uint32_t restrictions() const {
+    return restrictions_;
+  }
 
   /**
    * Set simple turn restrictions from the end of this directed edge.
@@ -361,7 +411,9 @@ class DirectedEdge {
    * Get the specialized use of this edge.
    * @return  Returns the use type of this edge.
    */
-  Use use() const;
+  Use use() const {
+    return static_cast<Use>(use_);
+  }
 
   /**
    * Sets the specialized use type of this edge.
@@ -373,13 +425,17 @@ class DirectedEdge {
    * Is this edge a transit line (bus or rail)?
    * @return  Returns true if this edge is a transit line.
    */
-  bool IsTransitLine() const;
+  bool IsTransitLine() const {
+    return (use() == Use::kRail || use() == Use::kBus);
+  }
 
   /**
    * Get the speed type (see graphconstants.h)
    * @return  Returns the speed type.
    */
-  SpeedType speed_type() const;
+  SpeedType speed_type() const {
+    return static_cast<SpeedType>(speed_type_);
+  }
 
   /**
    * Set the speed type (see graphconstants.h)
@@ -391,7 +447,9 @@ class DirectedEdge {
    * Get the country crossing flag.
    * @return  Returns true if the edge crosses into a new country.
    */
-  bool ctry_crossing() const;
+  bool ctry_crossing() const {
+    return ctry_crossing_;
+  }
 
   /**
    * Set the country crossing flag.
@@ -403,7 +461,9 @@ class DirectedEdge {
    * Get the access modes in the forward direction (bit field).
    * @return  Returns the access modes in the forward direction.
    */
-  uint32_t forwardaccess() const;
+  uint32_t forwardaccess() const  {
+    return forwardaccess_;
+  }
 
   /**
    * Set the access modes in the forward direction (bit field).
@@ -420,7 +480,9 @@ class DirectedEdge {
    * Get the access modes in the reverse direction (bit field).
    * @return  Returns the access modes in the reverse direction.
    */
-  uint32_t reverseaccess() const;
+  uint32_t reverseaccess() const {
+    return reverseaccess_;
+  }
 
   /**
    * Set the access modes in the reverse direction (bit field).
@@ -432,7 +494,9 @@ class DirectedEdge {
    * Gets the speed in KPH.
    * @return  Returns the speed in KPH.
    */
-  uint32_t speed() const;
+  uint32_t speed() const {
+    return speed_;
+  }
 
   /**
    * Sets the speed in KPH.
@@ -444,7 +508,9 @@ class DirectedEdge {
    * Gets the speed limit in KPH.
    * @return  Returns the speed limit in KPH.
    */
-  uint32_t speed_limit() const;
+  uint32_t speed_limit() const {
+    return speed_limit_;
+  }
 
   /**
    * Sets the speed limit in KPH.
@@ -456,7 +522,9 @@ class DirectedEdge {
    * Gets the truck speed in KPH.
    * @return  Returns the truck speed in KPH.
    */
-  uint32_t truck_speed() const;
+  uint32_t truck_speed() const {
+    return truck_speed_;
+  }
 
   /**
    * Sets the truck speed in KPH.
@@ -468,7 +536,9 @@ class DirectedEdge {
    * Get the classification (importance) of the road/path.
    * @return  Returns road classification / importance.
    */
-  RoadClass classification() const;
+  RoadClass classification() const {
+    return static_cast<RoadClass>(classification_);
+  }
 
   /**
    * Sets the classification (importance) of this edge.
@@ -479,13 +549,17 @@ class DirectedEdge {
   /**
    * Is this edge unpaved or bad surface?
    */
-  bool unpaved() const;
+  bool unpaved() const {
+    return (surface() >= Surface::kCompacted);
+  }
 
   /**
    * Get the surface type (see graphconstants.h). This is a general indication
    * of smoothness.
    */
-  Surface surface() const;
+  Surface surface() const {
+    return static_cast<Surface>(surface_);
+  }
 
   /**
    * Sets the surface type (see baldr/graphconstants.h). This is a general
@@ -497,7 +571,9 @@ class DirectedEdge {
   /**
    * Is this edge a link/ramp?
    */
-  bool link() const;
+  bool link() const {
+    return link_;
+  }
 
   /**
    * Sets the link flag indicating the edge is part of a link or connection
@@ -513,7 +589,9 @@ class DirectedEdge {
    * intersections.
    * @return  Returns true if the edge is internal to an intersection.
    */
-  bool internal() const;
+  bool internal() const {
+    return internal_;
+  }
 
   /**
    * Sets the intersection internal flag indicating the edge is "internal"
@@ -529,7 +607,9 @@ class DirectedEdge {
    * @return  Returns the starting mode for this complex restriction for the
    *          directed edge.
    */
-  uint32_t start_restriction() const;
+  uint32_t start_restriction() const {
+    return start_restriction_;
+  }
 
   /**
    * Set the modes which have a complex restriction starting on this edge.
@@ -542,7 +622,9 @@ class DirectedEdge {
    * @return  Returns the ending mode for this complex restriction for the
    *          directed edge.
    */
-  uint32_t end_restriction() const;
+  uint32_t end_restriction() const {
+    return end_restriction_;
+  }
 
   /**
    * Set the modes which have a complex restriction ending on this edge.
@@ -553,7 +635,9 @@ class DirectedEdge {
   /**
    * Is this edge part of a complex restriction?
    */
-  bool part_of_complex_restriction() const;
+  bool part_of_complex_restriction() const {
+    return part_of_complex_restriction_;
+  }
 
   /**
    * Sets the part of complex restriction flag indicating the edge is part
@@ -592,7 +676,9 @@ class DirectedEdge {
    * Get the density along the edges.
    * @return  Returns relative density along the edge.
    */
-  uint32_t density() const;
+  uint32_t density() const {
+    return density_;
+  }
 
   /**
    * Set the density along the edges.
@@ -604,7 +690,9 @@ class DirectedEdge {
    * Is there a sidewalk to the left of this directed edge?
    * @return  Returns true if there is a sidewalk to the left of this edge.
    */
-  bool sidewalk_left() const;
+  bool sidewalk_left() const {
+    return sidewalk_left_;
+  }
 
   /**
    * Set the flag for a sidewalk to the left of this directed edge.
@@ -616,7 +704,9 @@ class DirectedEdge {
    * Is there a sidewalk to the right of this directed edge?
    * @return  Returns true if there is a sidewalk to the right of this edge.
    */
-  bool sidewalk_right() const;
+  bool sidewalk_right() const {
+    return sidewalk_right_;
+  }
 
   /**
    * Set the flag for a sidewalk to the right of this directed edge.
@@ -630,7 +720,12 @@ class DirectedEdge {
    * @param  localidx  Local index at the node of the inbound edge.
    * @return  Returns the turn type (see turn.h)
    */
-  Turn::Type turntype(const uint32_t localidx) const;
+  Turn::Type turntype(const uint32_t localidx) const  {
+    // Turn type is 3 bits per index
+    uint32_t shift = localidx * 3;
+    return static_cast<Turn::Type>(
+        ((turntype_ & (7 << shift))) >> shift);
+  }
 
   /**
    * Sets the turn type given the prior edge's local index
@@ -645,7 +740,9 @@ class DirectedEdge {
    * @param localidx  Local index at the node of the inbound edge.
    * @return  Returns true if there is an edge to the left, false if not.
    */
-  bool edge_to_left(const uint32_t localidx) const;
+  bool edge_to_left(const uint32_t localidx) const {
+    return (edge_to_left_ & (1 << localidx));
+  }
 
   /**
    * Set the flag indicating there is an edge to the left, in between
@@ -661,7 +758,11 @@ class DirectedEdge {
    * @param  localidx  Local index at the node of the inbound edge.
    * @return  Returns the relative stop impact from low (0) to high (7).
    */
-  uint32_t stopimpact(const uint32_t localidx) const;
+  uint32_t stopimpact(const uint32_t localidx) const {
+    // Stop impact is 3 bits per index
+    uint32_t shift = localidx * 3;
+    return (stopimpact_.s.stopimpact & (7 << shift)) >> shift;
+  }
 
   /**
    * Set the stop impact when transitioning from the prior edge (given
@@ -675,7 +776,9 @@ class DirectedEdge {
    * Get the transit line Id (for departure lookups along an edge)
    * @return  Returns the transit line Id.
    */
-  uint32_t lineid() const;
+  uint32_t lineid() const {
+    return stopimpact_.lineid;
+  }
 
   /**
    * Set the unique transit line Id.
@@ -688,7 +791,9 @@ class DirectedEdge {
    * @param localidx  Local index at the node of the inbound edge.
    * @return  Returns true if there is an edge to the right, false if not.
    */
-  bool edge_to_right(const uint32_t localidx) const;
+  bool edge_to_right(const uint32_t localidx) const {
+    return (stopimpact_.s.edge_to_right & (1 << localidx));
+  }
 
   /**
    * Set the flag indicating there is an edge to the right, in between
@@ -704,7 +809,9 @@ class DirectedEdge {
    * identified on the different levels.
    * @return  Returns the index of the edge on the local level.
    */
-  uint32_t localedgeidx() const;
+  uint32_t localedgeidx() const {
+    return localedgeidx_;
+  }
 
   /** Set the index of the directed edge on the local level of the graph
    * hierarchy. This is used for turn restrictions so the edges can be
@@ -720,7 +827,9 @@ class DirectedEdge {
    * @return  Returns the index of the opposing directed edge on the local
    *          hierarchy level at end node of this directed edge.
    */
-  uint32_t opp_local_idx() const;
+  uint32_t opp_local_idx() const {
+    return opp_local_idx_;
+  }
 
   /**
    * Set the index of the opposing directed edge on the local hierarchy level
@@ -738,7 +847,9 @@ class DirectedEdge {
    * @return  Returns the shortcut mask of the matching superseded edge
    *          outbound from the node. 0 indicates the edge is not a shortcut.
    */
-  uint32_t shortcut() const;
+  uint32_t shortcut() const {
+    return shortcut_;
+   }
 
   /**
    * Set the mask for whether this edge represents a shortcut between 2 nodes.
@@ -756,7 +867,9 @@ class DirectedEdge {
    *          directed edge outbound from the node. 0 indicates the edge is not
    *          superseded by a shortcut edge.
    */
-  uint32_t superseded() const;
+  uint32_t superseded() const {
+    return superseded_;
+  }
 
   /**
    * Set the mask for whether this edge is superseded by a shortcut edge.
@@ -775,7 +888,9 @@ class DirectedEdge {
    * @return  Returns true if the edge is a transition from a lower level
    *          to a higher (false if not).
    */
-  bool trans_up() const;
+  bool trans_up() const {
+    return (use() == Use::kTransitionUp);
+  }
 
   /**
    * Set the use indicating this edge represents a transition up one level
@@ -795,7 +910,9 @@ class DirectedEdge {
    * @return  Returns true if the edge is a transition from an upper level
    *          to a lower (false if not).
    */
-  bool trans_down() const;
+  bool trans_down() const {
+    return (use() == Use::kTransitionDown);
+  }
 
   /**
    * Set the use indicating this edge represents a transition down one level
@@ -811,14 +928,18 @@ class DirectedEdge {
    * shortcuts no mask is set but this flag is set to true.
    * @return  Returns true if this edge is a shortcut.
    */
-  bool is_shortcut() const;
+  bool is_shortcut() const {
+    return is_shortcut_;
+  }
 
   /**
    * Does this directed edge end in a different tile.
    * @return  Returns true if the end node of this directed edge
    *          is in a different tile.
    */
-  bool leaves_tile() const;
+  bool leaves_tile() const {
+    return leaves_tile_;
+  }
 
   /**
    * Set the flag indicating whether the end node of this directed edge is in

--- a/valhalla/baldr/double_bucket_queue.h
+++ b/valhalla/baldr/double_bucket_queue.h
@@ -56,7 +56,9 @@ class DoubleBucketQueue {
    * @param   label  Label index to add to the adjacency list.
    * @param   cost   Cost for this label.
    */
-  void add(const uint32_t label, const float cost);
+  void add(const uint32_t label, const float cost) {
+    get_bucket(cost).push_back(label);
+  }
 
   /**
    * The specified label index now has a smaller cost.  Reorders it in the
@@ -101,7 +103,12 @@ class DoubleBucketQueue {
    * @param  cost  Cost.
    * @return Returns the bucket that the cost lies within.
    */
-  std::deque<uint32_t>& get_bucket(const float cost);
+  std::deque<uint32_t>& get_bucket(const float cost) {
+    return (cost < currentcost_) ? *currentbucket_ :
+             (cost < maxcost_) ?
+               buckets_[static_cast<uint32_t>((cost - mincost_) * inv_)] :
+               overflowbucket_;
+  }
 
   /**
    * Empties the overflow bucket by placing the label indexes into the

--- a/valhalla/baldr/graphtileheader.h
+++ b/valhalla/baldr/graphtileheader.h
@@ -12,8 +12,8 @@ namespace baldr {
 // Number of expansion slots remaining in this tile. If you want to add
 // something to the tile simply subtract one from this number and add it
 // just before the empty_slots_ array below. NOTE that it can ONLY be an
-// offset in bytes  and NOT a bitfield or union or anything of that sort
-constexpr size_t kEmptySlots = 16;
+// offset in bytes and NOT a bitfield or union or anything of that sort
+constexpr size_t kEmptySlots = 17;
 
 // Maximum size of the version string (stored as a fixed size
 // character array so the GraphTileHeader size remains fixed).
@@ -390,10 +390,6 @@ class GraphTileHeader {
   // kEmptySlots by 1. Note that you can ONLY add an offset here and NOT a
   // bitfield or union or anything like that
   uint32_t empty_slots_[kEmptySlots];
-
-  // End offset - fixed location in the header
-  uint32_t end_offset_;
-
 };
 
 }

--- a/valhalla/baldr/nodeinfo.h
+++ b/valhalla/baldr/nodeinfo.h
@@ -54,7 +54,9 @@ class NodeInfo {
    * Get the latitude, longitude of the node.
    * @return  Returns the latitude and longitude of the node.
    */
-  const PointLL& latlng() const;
+  const PointLL& latlng() const {
+    return static_cast<const PointLL&>(latlng_);
+  }
 
   /**
    * Sets the latitude and longitude.
@@ -68,7 +70,9 @@ class NodeInfo {
    * only need an index within the tile.
    * @return  Returns the GraphId of the first outbound edge.
    */
-  uint32_t edge_index() const;
+  uint32_t edge_index() const {
+    return edge_index_;
+  }
 
   /**
    * Set the index within the node's tile of its first outbound edge.
@@ -81,7 +85,9 @@ class NodeInfo {
    * present on the current hierarchy level.
    * @return  Returns the number of outbound directed edges.
    */
-  uint32_t edge_count() const;
+  uint32_t edge_count() const {
+    return edge_count_;
+  }
 
   /**
    * Set the number of outbound directed edges.
@@ -94,7 +100,9 @@ class NodeInfo {
    * See graphconstants.h for access constants.
    * @return  Returns the access bit mask indicating allowable modes.
    */
-  uint16_t access() const;
+  uint16_t access() const {
+    return access_;
+  }
 
   /**
    * Set the access modes (bit mask) allowed to pass through the node.
@@ -107,7 +115,9 @@ class NodeInfo {
    * Get the intersection type.
    * @return  Returns the intersection type.
    */
-  IntersectionType intersection() const;
+  IntersectionType intersection() const {
+    return static_cast<IntersectionType>(intersection_);
+  }
 
   /**
    * Set the intersection type.
@@ -119,7 +129,9 @@ class NodeInfo {
    * Get the index of the administrative information within this tile.
    * @return  Returns an index within the tile's administrative information.
    */
-  uint32_t admin_index() const;
+  uint32_t admin_index() const {
+    return admin_index_;
+  }
 
   /**
    * Set the index of the administrative information within this tile.
@@ -131,7 +143,9 @@ class NodeInfo {
    * Returns the timezone index. TODO - describe the timezone information.
    * @return  Returns the timezone index.
    */
-  uint32_t timezone() const;
+  uint32_t timezone() const {
+    return timezone_;
+  }
 
   /**
    * Set the timezone index.
@@ -145,7 +159,10 @@ class NodeInfo {
    * @param  localidx  Local edge index.
    * @return Returns traversability (see graphconstants.h)
    */
-  Traversability local_driveability(const uint32_t localidx) const;
+  Traversability local_driveability(const uint32_t localidx) const {
+    uint32_t s = localidx * 2;     // 2 bits per index
+    return static_cast<Traversability>((local_driveability_ & (3 << s)) >> s);
+  }
 
   /**
    * Set the auto driveability of the local directed edge given a local
@@ -160,7 +177,9 @@ class NodeInfo {
    * Get the relative road density at the node.
    * @return  Returns relative density (0-15).
    */
-  uint32_t density() const;
+  uint32_t density() const {
+    return density_;
+  }
 
   /**
    * Set the relative road density
@@ -172,7 +191,9 @@ class NodeInfo {
    * Gets the node type. See graphconstants.h for the list of types.
    * @return  Returns the node type.
    */
-  NodeType type() const;
+  NodeType type() const {
+    return static_cast<NodeType>(type_);
+  }
 
   /**
    * Set the node type.
@@ -184,7 +205,9 @@ class NodeInfo {
    * Checks if this node is a transit node.
    * @return  Returns true if this node is a transit node.
    */
-  bool is_transit() const;
+  bool is_transit() const {
+    return type() == NodeType::kMultiUseTransitStop;
+  }
 
   /**
    * Get the number of regular edges across all levels (up to
@@ -192,7 +215,9 @@ class NodeInfo {
    * transit edges and transit connections, and transition edges.
    * @return  Returns the number of edges on the local level.
    */
-  uint32_t local_edge_count() const;
+  uint32_t local_edge_count() const {
+    return local_edge_count_ + 1;
+  }
 
   /**
    * Set the number of edges on the local level (up to kMaxLocalEdgeInfo+1).
@@ -206,7 +231,9 @@ class NodeInfo {
    * share locations, and parking locations.
    * @return  Returns true if mode changes are allowed.
    */
-  bool mode_change() const;
+  bool mode_change() const {
+    return mode_change_;
+  }
 
   /**
    * Sets the flag indicating a mode change is allowed at this node.
@@ -220,7 +247,9 @@ class NodeInfo {
    * Is there a traffic signal at this node?
    * @return  Returns true if there is a traffic signal at the node.
    */
-  bool traffic_signal() const;
+  bool traffic_signal() const {
+    return traffic_signal_;
+  }
 
   /**
    * Set the traffic signal flag.
@@ -233,7 +262,9 @@ class NodeInfo {
    * and possibly queries to a transit service.
    * @return  Returns the transit stop index.
    */
-  uint32_t stop_index() const;
+  uint32_t stop_index() const {
+    return stop_.stop_index;
+  }
 
   /**
    * Set the transit stop index.


### PR DESCRIPTION
This leads to a good performance improvement. Also, go back to using empty_slots[0] for the end of tile
offset, but set all epty slots to the end offset value so that different data versions and code still work.