### PR TITLE
Merged master and fixed a bug

### DIFF
--- a/src/baldr/merge.cc
+++ b/src/baldr/merge.cc
@@ -142,14 +142,6 @@ std::pair<GraphId, GraphId> edge_collapser::nodes_reachable_from(GraphId node_id
       continue;
     }
 
-    // if we encounter any edges which have already been marked, then this
-    // node cannot be collapsible. either that edge would be one of the two
-    // needed at this node to make it collapsible, or the node has more than
-    // two edges.
-    if (m_tracker.get(edge.second)) {
-      return none;
-    }
-
     if (first) {
       if (second) {
         // can't add a third, that means this node is a true junction.
@@ -211,6 +203,12 @@ GraphId edge_collapser::edge_between(GraphId cur, GraphId next) {
 void edge_collapser::explore(GraphId node_id) {
   auto nodes = nodes_reachable_from(node_id);
   if (!nodes.first || !nodes.second) {
+    return;
+  }
+
+  // if either edge has been marked, then don't explore down either of them.
+  if (m_tracker.get(edge_between(node_id, nodes.first)) ||
+      m_tracker.get(edge_between(node_id, nodes.second))) {
     return;
   }
 

--- a/valhalla/baldr/errorcode_util.h
+++ b/valhalla/baldr/errorcode_util.h
@@ -186,6 +186,7 @@ namespace baldr {
     {442,"No path could be found for input"},
     {443,"Exact route match algorithm failed to find path"},
     {444,"Map Match algorithm failed to find path"},
+    {445,"Shape match algorithm specification in api request is incorrect. Please see documentation for valid shape_match input."},
 
     {499,"Unknown"},
 


### PR DESCRIPTION
NOTE: this is a merge into the segments branch, not master.

The loop which was exploring edges was testing the mark on "seen" edges, which meant that it would see the mark it just made and assume that the edge could not be explored. Checking the mark is necessary before starting to explore a node, to ensure that edges are not explored twice. However, in the exploration loop it is not required, and prevents segments of longer than length 2 being created.

I've added a simple test case for this as well.

@dnesbitt61 could you review, please?