### PR TITLE
Return nullptr from GetGraphTile if lat,lon is out of range

### DIFF
--- a/src/baldr/graphreader.cc
+++ b/src/baldr/graphreader.cc
@@ -135,7 +135,8 @@ const GraphTile* GraphReader::GetGraphTile(const GraphId& graphid) {
 }
 
 const GraphTile* GraphReader::GetGraphTile(const PointLL& pointll, const uint8_t level){
-  return GetGraphTile(tile_hierarchy_.GetGraphId(pointll, level));
+  GraphId id = tile_hierarchy_.GetGraphId(pointll, level);
+  return (id.Is_Valid()) ? GetGraphTile(tile_hierarchy_.GetGraphId(pointll, level)) : nullptr;
 }
 
 const GraphTile* GraphReader::GetGraphTile(const PointLL& pointll){

--- a/src/baldr/tilehierarchy.cc
+++ b/src/baldr/tilehierarchy.cc
@@ -28,7 +28,10 @@ GraphId TileHierarchy::GetGraphId(const midgard::PointLL& pointll, const unsigne
   GraphId id;
   const auto& tl = levels_.find(level);
   if(tl != levels_.end()) {
-    id.Set(static_cast<int32_t>(tl->second.tiles.TileId(pointll)), level, 0);
+    auto tile_id = tl->second.tiles.TileId(pointll);
+    if (tile_id >= 0) {
+      id.Set(tile_id, level, 0);
+    }
   }
   return id;
 }

--- a/test/graphreader.cc
+++ b/test/graphreader.cc
@@ -31,6 +31,20 @@ test_reader make_cache(std::string cache_size) {
   return {pt};
 }
 
+void TestOutOfRangeLL() {
+  boost::property_tree::ptree pt;
+  pt.put("tile_dir", "test/gphrdr_test");
+  GraphReader reader(pt);
+
+  // Latitude out of range
+  if (reader.GetGraphTile({60.0f, 100.0f}) != nullptr)
+    throw std::runtime_error("Out of range LL should return nullptr");
+
+  // Out of range longitude
+  if (reader.GetGraphTile({460.0f, 60.0f}) != nullptr)
+    throw std::runtime_error("Out of range LL should return nullptr");
+}
+
 void TestCacheLimits() {
   if(make_cache("\"max_cache_size\": 0,").OverCommitted())
     throw std::runtime_error("Cache should be over committed");
@@ -127,6 +141,8 @@ void TestConnectivityMap() {
 
 int main() {
   test::suite suite("graphtile");
+
+  suite.test(TEST_CASE(TestOutOfRangeLL));
 
   suite.test(TEST_CASE(TestCacheLimits));
 

--- a/valhalla/baldr/edgeinfo.h
+++ b/valhalla/baldr/edgeinfo.h
@@ -133,7 +133,8 @@ class EdgeInfo {
   struct PackedItem {
     uint32_t name_count          :4;
     uint32_t encoded_shape_size  :16;
-    uint32_t spare               :12;
+    uint32_t reserved            :5;   // Reserved for use by forks of Valhalla
+    uint32_t spare               :7;
   };
 
  protected:


### PR DESCRIPTION
Since tile extent can be configurable it doesn't make sense to normalize lat,lon if out or normal ranges.

Fixes #334 