### PR TITLE
Add bounding-box based "GetTiles" to TileHierarchy

### DIFF
--- a/src/baldr/tilehierarchy.cc
+++ b/src/baldr/tilehierarchy.cc
@@ -47,5 +47,24 @@ uint8_t TileHierarchy::get_level(const RoadClass roadclass) const {
   }
 }
 
+std::vector<GraphId> TileHierarchy::GetGraphIds(
+  const midgard::AABB2<midgard::PointLL> &bbox,
+  uint8_t level) const {
+
+  std::vector<GraphId> ids;
+
+  auto itr = levels_.find(level);
+  if (itr != levels_.end()) {
+    auto tile_ids = itr->second.tiles.TileList(bbox);
+    ids.reserve(tile_ids.size());
+
+    for (auto tile_id : tile_ids) {
+      ids.emplace_back(tile_id, level, 0);
+    }
+  }
+
+  return ids;
+}
+
 }
 }

--- a/src/baldr/tilehierarchy.cc
+++ b/src/baldr/tilehierarchy.cc
@@ -66,5 +66,19 @@ std::vector<GraphId> TileHierarchy::GetGraphIds(
   return ids;
 }
 
+std::vector<GraphId> TileHierarchy::GetGraphIds(
+  const midgard::AABB2<midgard::PointLL> &bbox) const {
+
+  std::vector<GraphId> ids;
+
+  for (const auto &entry : levels_) {
+    auto level_ids = GetGraphIds(bbox, entry.first);
+    ids.reserve(ids.size() + level_ids.size());
+    ids.insert(ids.end(), level_ids.begin(), level_ids.end());
+  }
+
+  return ids;
+}
+
 }
 }

--- a/test/tilehierarchy.cc
+++ b/test/tilehierarchy.cc
@@ -43,6 +43,27 @@ namespace {
     if(h.levels().rbegin()->second.importance != RoadClass::kServiceOther)
       throw runtime_error("Importance should be set to service/other");
   }
+
+  void test_tiles() {
+    TileHierarchy h("/data/valhalla");
+
+    //there are 1440 cols and 720 rows, this spot lands on col 414 and row 522
+    AABB2<PointLL> bbox{{-76.49, 40.51}, {-76.48, 40.52}};
+    auto ids = h.GetGraphIds(bbox, 2);
+    if (ids.size() != 1) {
+      throw runtime_error("Should have only found one result.");
+    }
+    auto id = ids[0];
+    if (id.level() != 2 || id.tileid() != (522 * 1440) + 414 || id.id() != 0) {
+      throw runtime_error("Didn't find correct tile ID.");
+    }
+
+    bbox = AABB2<PointLL>{{-76.51, 40.49}, {-76.49, 40.51}};
+    ids = h.GetGraphIds(bbox, 2);
+    if (ids.size() != 4) {
+      throw runtime_error("Should have found 4 results.");
+    }
+  }
 }
 
 int main(void)
@@ -50,6 +71,7 @@ int main(void)
   test::suite suite("tilehierarchy");
 
   suite.test(TEST_CASE(test_parse));
+  suite.test(TEST_CASE(test_tiles));
 
   return suite.tear_down();
 }

--- a/valhalla/baldr/tilehierarchy.h
+++ b/valhalla/baldr/tilehierarchy.h
@@ -66,6 +66,15 @@ class TileHierarchy {
   GraphId GetGraphId(const midgard::PointLL& pointll, const uint8_t level) const;
 
   /**
+   * Returns all the graphids of the tiles which intersect the given bounding
+   * box at that level.
+   *
+   * @param bbox  the bounding box of tiles to find.
+   * @param level the level of the tiles to return.
+   */
+  std::vector<GraphId> GetGraphIds(const midgard::AABB2<midgard::PointLL> &bbox, uint8_t level) const;
+
+  /**
    * Gets the hierarchy level given the road class.
    * @param  road_class  Road classification.
    * @return Returns the level.

--- a/valhalla/baldr/tilehierarchy.h
+++ b/valhalla/baldr/tilehierarchy.h
@@ -75,6 +75,14 @@ class TileHierarchy {
   std::vector<GraphId> GetGraphIds(const midgard::AABB2<midgard::PointLL> &bbox, uint8_t level) const;
 
   /**
+   * Returns all the graphids of the tiles which intersect the given bounding
+   * box at any level.
+   *
+   * @param bbox  the bounding box of tiles to find.
+   */
+  std::vector<GraphId> GetGraphIds(const midgard::AABB2<midgard::PointLL> &bbox) const;
+
+  /**
    * Gets the hierarchy level given the road class.
    * @param  road_class  Road classification.
    * @return Returns the level.


### PR DESCRIPTION
Add a couple of convenient functions to `TileHierarchy` to return the IDs of tiles which intersect given bounding boxes at some or all levels.

@kevinkreiser could you review, please?