### PR TITLE
Updates to TrafficAssociation structures

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -120,7 +120,6 @@ libvalhalla_baldr_la_SOURCES = \
 	src/baldr/streetnames_factory.cc \
 	src/baldr/streetname_us.cc \
 	src/baldr/streetnames_us.cc \
-	src/baldr/trafficassociation.cc \
 	src/baldr/transitdeparture.cc \
 	src/baldr/transitroute.cc \
 	src/baldr/transitschedule.cc \

--- a/valhalla/baldr/graphtile.h
+++ b/valhalla/baldr/graphtile.h
@@ -308,15 +308,7 @@ class GraphTile {
    * @return  Returns a list of traffic segment Ids and weights that associate
    *          to this edge.
    */
-  std::vector<std::pair<TrafficAssociation, float>> GetTrafficSegments(const GraphId& edge) const;
-
-  /**
-   * Get traffic segment(s) associated to this edge.
-   * @param  edge  GraphId of the directed edge.
-   * @return  Returns a list of traffic segment Ids and weights that associate
-   *          to this edge.
-   */
-  std::vector<std::pair<TrafficAssociation, float>> GetTrafficSegments(const size_t idx) const;
+  std::vector<TrafficSegment> GetTrafficSegments(const size_t idx) const;
 
 
  protected:

--- a/valhalla/baldr/graphtile.h
+++ b/valhalla/baldr/graphtile.h
@@ -397,7 +397,7 @@ class GraphTile {
 
   // Traffic chunks. Chunks are an array of uint64_t which combines a traffic
   // segment Id (GraphId) and weight (combined int a single uint64_t).
-  uint64_t* traffic_chunks_;
+  TrafficChunk* traffic_chunks_;
 
   // Number of bytes in the traffic chunk list
   std::size_t traffic_chunk_size_;

--- a/valhalla/baldr/trafficassociation.h
+++ b/valhalla/baldr/trafficassociation.h
@@ -6,10 +6,10 @@
 namespace valhalla {
 namespace baldr {
 
-// 6 bits are used for percentages and weights in traffic associations
-constexpr uint64_t kEndsSegment   = 63;
-constexpr float kPercentFactor    = 63.0f;
-constexpr float kInvPercentFactor = 1.0f / 63.0f;
+// 8 bits are used for percentages
+//constexpr uint64_t kEndsSegment   = 255;
+constexpr float kPercentFactor    = 255.0f;
+constexpr float kInvPercentFactor = 1.0f / 255.0f;
 
 // These are used to indicate a chunk is stored for this edge's
 // association to traffic segments. A chunk count and chunk index
@@ -18,48 +18,132 @@ constexpr uint64_t kChunkCountMask  = 0x00000fff00000000;
 constexpr uint64_t kChunkCountShift = 32;
 constexpr uint64_t kChunkIndexMask  = 0x00000000ffffffff;
 
+// Structure used to return information
+struct TrafficSegment {
+  GraphId segment_id_;
+  float begin_percent_;
+  float end_percent_;
+  bool starts_segment_;
+  bool ends_segment_;
+
+  TrafficSegment(const GraphId& id, const float begin_pct,
+                 const float end_pct, const bool starts, const bool ends)
+      : segment_id_(id),
+        begin_percent_(begin_pct),
+        end_percent_(end_pct),
+        starts_segment_(starts),
+        ends_segment_(ends) {
+  }
+};
+
 /**
  * TrafficChunk describes many to one and many to many associations of
- * traffic segments to edges. This is similar to the traffic association
- * structure except that a "weight" is added to indicate the weight or
- * percent of the segment applied to this edge.
+ * traffic segments to edges. They are also used for cases where a segment
+ * is not within the same tile as the edge (at tile boundaries or if segment
+ * is associated to an edge on a different hierarchy level). There can be
+ * multiple chunks per edge.
  */
-struct TrafficChunk {
-  uint64_t segment_id_    : 46;  // Traffic segment Id
-  uint64_t begin_percent_ : 6;   // Begin percent along the segment
-  uint64_t end_percent_   : 6;   // End percent along the segment
-  uint64_t weight_        : 6;   // Weight (percentage this traffic segment
-                                 // applies to the edge)
-
+class TrafficChunk {
+ public:
   /**
    * Constructor with arguments
    */
   TrafficChunk(const GraphId& segment_id, const float begin_percent,
-               const float end_percent, const float weight);
+               const float end_percent, const bool starts, const bool ends)
+      : segment_id_(segment_id.value),
+        begin_percent_(begin_percent  * kPercentFactor),
+        end_percent_(end_percent * kPercentFactor),
+        starts_segment_(starts),
+        ends_segment_(ends) {
+  }
+
+  /**
+   * Get the traffic segment Id.
+   * @return  Returns the GraphId of the traffic segment for this chunk.
+   */
+  GraphId segment_id() const {
+    return GraphId(segment_id_);
+  }
+
+  /**
+   * Get the begin percent of this traffic segment along the edge.
+   * @return  Returns percent (floating point)
+   */
+  float begin_percent() const {
+    return begin_percent_ * kInvPercentFactor;
+  }
+
+  /**
+   * Get the end  percent of this traffic segment along the edge.
+   * @return  Returns percent (floating point)
+   */
+  float end_percent() const {
+    return end_percent_ * kInvPercentFactor;
+  }
+
+  /**
+   * Does this directed edge start at the beginning of the traffic segment.
+   * @return  Returns true if this edge starts at the beginning of the
+   *          traffic segment.
+   */
+  bool starts_segment() const {
+    return starts_segment_;
+  }
+
+  /**
+   * Does this directed edge ends at the end of the traffic segment.
+   * @return  Returns true if this edge ends at the end of the
+   *          traffic segment.
+   */
+  bool ends_segment() const {
+    return ends_segment_;
+  }
+
+ private:
+  uint64_t segment_id_     : 46; // Traffic segment Id
+  uint64_t begin_percent_  : 8;  // Begin percent of the segment along the edge
+  uint64_t end_percent_    : 8;  // End percent of the segment along the edge
+  uint64_t starts_segment_ : 1;  // Edge starts this traffic segment
+  uint64_t ends_segment_   : 1;  // Edge ends this traffic segment
 };
 
 /**
  * Information to associate a Valhalla directed edge to OSMLR traffic
  * segments. Includes the segment Id as well as information to localize
- * it to all or part of the traffic segment.
+ * it to all or part of the traffic segment. TrafficAssociation structure
+ * is used for 1:1 and 1:many cases (traffic segment to edge association)
+ * AND the associated segment is in the same tile. A chunk is used if the
+ * segment is in a different tile.
  */
 class TrafficAssociation {
  public:
   /**
    * Default constructor.
    */
-  TrafficAssociation();
+  TrafficAssociation()
+     : id_(0),
+       count_(0),
+       starts_segment_(false),
+       ends_segment_(false),
+       chunk_(false) {
+  }
 
   /**
    * Constructor with arguments.
-   * @param  segment_id     Traffic segment Id.
-   * @param  begin_percent  Percentage along the segment at the beginning
+   * @param  id      Traffic segment Id (within this tile)
+   * @param  starts  Percentage along the segment at the beginning
    *                        of the edge.
-   * @param  end_percent    Percentage along the segment at the end
+   * @param  ends    Percentage along the segment at the end
    *                        of the edge.
    */
-  TrafficAssociation(const GraphId& segment_id, const float begin_percent,
-                     const float end_percent);
+  TrafficAssociation(const uint32_t id, const bool starts,
+                     const bool ends)
+      : id_(id),
+        count_(1),
+        starts_segment_(starts),
+        ends_segment_(ends),
+        chunk_(false) {
+  }
 
   /**
    * Constructor with arguments. Used when the edge associates to a traffic
@@ -67,78 +151,74 @@ class TrafficAssociation {
    * @param  chunk_count    Count of chunks associated to this edge.
    * @param  chunk_index    Index into the list of chunks.
    */
-  TrafficAssociation(const uint32_t chunk_count, const uint32_t chunk_index);
-
-  /**
-   * Create a TrafficAssociation record from a chunk.
-   * @param  chunk  Traffic association chunk.
-   */
-  TrafficAssociation(const TrafficChunk& chunk);
+  TrafficAssociation(const size_t chunk_count, const size_t chunk_index)
+    :  id_(static_cast<uint32_t>(chunk_index)),
+       count_(static_cast<uint32_t>(chunk_count)),
+       starts_segment_(false),
+       ends_segment_(false),
+       chunk_(true) {
+  }
 
   /**
    * Get the traffic segment Id.
-   * @return  Returns the OSMLR traffic segment Id.
+   * @return  Returns the segment Id within the current tile.
    */
-  GraphId segment_id() const;
+  uint32_t id() const {
+    return id_;
+  }
 
   /**
-   * Set the traffic segment Id.
-   * @param  id  Segment Id.
+   * Get the traffic segment count. This will be 0 if there is no associated
+   * traffic segment.
+   * @return  Returns the count (0 if no associated segment, 1 if a valid
+   *          association within this tile, and >0 if associated to a chunk).
    */
-  void set_segment_id(const GraphId& id);
-
-  /**
-   * Get the percentage along the traffic segment for the beginning of the
-   * directed edge.
-   * @return  Returns the percent along the traffic segment (0-1).
-   */
-  float begin_percent() const;
-
-  /**
-   * Get the percentage along the traffic segment for the end of the
-   * directed edge.
-   * @return  Returns the percent along the traffic segment (0-1).
-   */
-  float end_percent() const;
+  uint32_t count() const {
+    return count_;
+  }
 
   /**
    * Does this directed edge start at the beginning of the traffic segment.
    * @return  Returns true if this edge starts at the beginning of the
    *          traffic segment.
    */
-  bool starts_segment() const;
+  bool starts_segment() const {
+    return starts_segment_;
+  }
 
   /**
    * Does this directed edge ends at the end of the traffic segment.
    * @return  Returns true if this edge ends at the end of the
    *          traffic segment.
    */
-  bool ends_segment() const;
+  bool ends_segment() const {
+    return ends_segment_;
+  }
 
   /**
    * Does this edge associate to a traffic chunk (rather than a single
    * traffic segment).
    * @return  Returns true if this edge associates to a chunk.
    */
-  bool chunk() const;
+  bool chunk() const {
+    return chunk_;
+  }
 
   /**
    * Gets the chunk count and index.
    * @return  Returns a pair which includes the chunk count and index.
    */
-  std::pair<uint64_t, uint64_t> GetChunkCountAndIndex() const;
+  std::pair<uint32_t, uint32_t> GetChunkCountAndIndex() const {
+    return std::make_pair(count_, id_);
+  }
 
  protected:
-
-  // NOTE: If this association is part of a chunk (chunk_ flag is set), then
-  // the segment_id points to an index and count of chunks.
-  uint64_t segment_id_              : 46;  // Traffic segment Id
-  uint64_t begin_percent_           : 6;   // Begin percent
-  uint64_t end_percent_             : 6;   // End percent
-  uint64_t starts_segment_          : 1;   // Start of the traffic segment
-  uint64_t ends_segment_            : 1;   // End of the traffic segment
-  uint64_t chunk_                   : 1;   // This is part of a chunk
-  uint64_t spare_                   : 3;
+  uint32_t id_              : 21; // Traffic segment Id (within same tile)
+                                  // Chunk index if a chunk
+  uint32_t count_           : 8;  // If a chunk
+  uint32_t starts_segment_  : 1;  // Start of the traffic segment
+  uint32_t ends_segment_    : 1;  // End of the traffic segment
+  uint32_t chunk_           : 1;  // This is part of a chunk
 };
 
 }

--- a/valhalla/baldr/trafficassociation.h
+++ b/valhalla/baldr/trafficassociation.h
@@ -7,16 +7,8 @@ namespace valhalla {
 namespace baldr {
 
 // 8 bits are used for percentages
-//constexpr uint64_t kEndsSegment   = 255;
 constexpr float kPercentFactor    = 255.0f;
 constexpr float kInvPercentFactor = 1.0f / 255.0f;
-
-// These are used to indicate a chunk is stored for this edge's
-// association to traffic segments. A chunk count and chunk index
-// are stored in the association word.
-constexpr uint64_t kChunkCountMask  = 0x00000fff00000000;
-constexpr uint64_t kChunkCountShift = 32;
-constexpr uint64_t kChunkIndexMask  = 0x00000000ffffffff;
 
 // Structure used to return information
 struct TrafficSegment {


### PR DESCRIPTION
Use less memory for the most common case: a 1:1 edge to segment association where the segment is in the same tile as the edge. Also update the TrafficChunk structure. Add a new structure, TrafficSegment, to return from the graph tile.